### PR TITLE
Feat/murmur_update

### DIFF
--- a/pallets/murmur/Cargo.toml
+++ b/pallets/murmur/Cargo.toml
@@ -32,7 +32,9 @@ sp-runtime = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = 
 sp-core = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
 ckb-merkle-mountain-range = { version = "0.5.2", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
-murmur-core = { package = "murmur-core", git = "https://github.com/ideal-lab5/murmur.git", branch = "dev", default-features = false }
+murmur-core = { package = "murmur-core", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
+ark-transcript = { git = "https://github.com/w3f/ring-vrf.git", default-features = false}
+w3f-bls = { version = "0.1.3", default-features = false }
 
 # local dependencies
 pallet-proxy = { default-features = false, path = "../proxy" }
@@ -51,13 +53,13 @@ pallet-beefy-mmr-etf = { path = "../beefy-mmr-etf", default-features = false }
 sp-consensus-beefy-etf = { path = "../../primitives/consensus/beefy-etf", default-features = false, features = ["serde", "bls-experimental"] }
 sp-state-machine = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
 rand_chacha ="0.3.1"
+rand_core = { version = "0.6.4", features = ["getrandom"], default-features = false }
 ark-std = { version = "0.4.0", default-features = false }
 hex = "0.4.3"
 sp-io = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false  }
 etf-crypto-primitives = { default-features =  false, git = "https://github.com/ideal-lab5/etf-sdk.git", branch = "dev"}
-w3f-bls = { version = "0.1.3", default-features = false }
 binary-merkle-tree = { version = "15.0.0", default-features = false }
-murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "dev", default-features = false }
+murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
 
 [features]
 default = ["std"]
@@ -92,6 +94,8 @@ std = [
 	"binary-merkle-tree/std",
 	"sp-state-machine/std",
 	"murmur-test-utils/std",
+	"ark-transcript/std",
+	"rand_core/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/pallets/murmur/Cargo.toml
+++ b/pallets/murmur/Cargo.toml
@@ -59,7 +59,7 @@ hex = "0.4.3"
 sp-io = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false  }
 etf-crypto-primitives = { default-features =  false, git = "https://github.com/ideal-lab5/etf-sdk.git", branch = "dev"}
 binary-merkle-tree = { version = "15.0.0", default-features = false }
-murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", deafult-features = false }
+murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
 env_logger = "*"
 
 [features]

--- a/pallets/murmur/Cargo.toml
+++ b/pallets/murmur/Cargo.toml
@@ -60,6 +60,7 @@ sp-io = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "test
 etf-crypto-primitives = { default-features =  false, git = "https://github.com/ideal-lab5/etf-sdk.git", branch = "dev"}
 binary-merkle-tree = { version = "15.0.0", default-features = false }
 murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
+env_logger = "*"
 
 [features]
 default = ["std"]

--- a/pallets/murmur/Cargo.toml
+++ b/pallets/murmur/Cargo.toml
@@ -32,8 +32,8 @@ sp-runtime = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = 
 sp-core = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
 ckb-merkle-mountain-range = { version = "0.5.2", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
-murmur-core = { package = "murmur-core", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
-ark-transcript = { git = "https://github.com/w3f/ring-vrf.git", default-features = false}
+# murmur-core = { package = "murmur-core", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
+murmur-core = { path = "../../../murmur/core", default-features = false }
 w3f-bls = { version = "0.1.3", default-features = false }
 
 # local dependencies
@@ -41,6 +41,7 @@ pallet-proxy = { default-features = false, path = "../proxy" }
 pallet-randomness-beacon = { default-features = false, path = "../randomness-beacon"}
 
 [dev-dependencies]
+ark-transcript = { git = "https://github.com/w3f/ring-vrf.git", default-features = false }
 frame-support-test = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
 sp-staking = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
 pallet-balances = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
@@ -59,7 +60,8 @@ hex = "0.4.3"
 sp-io = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false  }
 etf-crypto-primitives = { default-features =  false, git = "https://github.com/ideal-lab5/etf-sdk.git", branch = "dev"}
 binary-merkle-tree = { version = "15.0.0", default-features = false }
-murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
+# murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
+murmur-test-utils = { path = "../../../murmur/test-utils", default-features = false }
 env_logger = "*"
 
 [features]
@@ -76,6 +78,7 @@ std = [
 	"sp-runtime/std",
 	"sp-io/std",
 	"sp-core/std",
+	"ark-transcript/std",
 	"ark-serialize/std",
 	"ark-bls12-381/std",
 	"pallet-balances/std",
@@ -95,7 +98,6 @@ std = [
 	"binary-merkle-tree/std",
 	"sp-state-machine/std",
 	"murmur-test-utils/std",
-	"ark-transcript/std",
 	"rand_core/std",
 ]
 runtime-benchmarks = [

--- a/pallets/murmur/Cargo.toml
+++ b/pallets/murmur/Cargo.toml
@@ -32,7 +32,8 @@ sp-runtime = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = 
 sp-core = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
 ckb-merkle-mountain-range = { version = "0.5.2", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
-murmur-core = { package = "murmur-core", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
+# murmur-core = { package = "murmur-core", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
+murmur-core = { path = "../../../murmur/core", default-features = false }
 ark-transcript = { git = "https://github.com/w3f/ring-vrf.git", default-features = false}
 w3f-bls = { version = "0.1.3", default-features = false }
 
@@ -59,7 +60,8 @@ hex = "0.4.3"
 sp-io = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false  }
 etf-crypto-primitives = { default-features =  false, git = "https://github.com/ideal-lab5/etf-sdk.git", branch = "dev"}
 binary-merkle-tree = { version = "15.0.0", default-features = false }
-murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
+# murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", deafult-features = false }
+murmur-test-utils = { path = "../../../murmur/test-utils/" }
 env_logger = "*"
 
 [features]

--- a/pallets/murmur/Cargo.toml
+++ b/pallets/murmur/Cargo.toml
@@ -32,8 +32,7 @@ sp-runtime = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = 
 sp-core = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
 ckb-merkle-mountain-range = { version = "0.5.2", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
-# murmur-core = { package = "murmur-core", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
-murmur-core = { path = "../../../murmur/core", default-features = false }
+murmur-core = { package = "murmur-core", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", default-features = false }
 ark-transcript = { git = "https://github.com/w3f/ring-vrf.git", default-features = false}
 w3f-bls = { version = "0.1.3", default-features = false }
 
@@ -60,8 +59,7 @@ hex = "0.4.3"
 sp-io = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false  }
 etf-crypto-primitives = { default-features =  false, git = "https://github.com/ideal-lab5/etf-sdk.git", branch = "dev"}
 binary-merkle-tree = { version = "15.0.0", default-features = false }
-# murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", deafult-features = false }
-murmur-test-utils = { path = "../../../murmur/test-utils/" }
+murmur-test-utils = { package = "murmur-test-utils", git = "https://github.com/ideal-lab5/murmur.git", branch = "feat/update", deafult-features = false }
 env_logger = "*"
 
 [features]

--- a/pallets/murmur/src/lib.rs
+++ b/pallets/murmur/src/lib.rs
@@ -33,13 +33,14 @@ use frame_support::{
 	traits::{ConstU32, IsSubType},
 };
 use murmur_core::{
-	murmur,
+	murmur::verifier::{verify_execute, verify_update},
 	types::{Leaf, MergeLeaves},
 };
 use pallet_randomness_beacon::TimelockEncryptionProvider;
 use scale_info::TypeInfo;
 use sp_runtime::traits::Dispatchable;
 use sp_std::{vec, vec::Vec};
+use w3f_bls::TinyBLS377;
 
 /// A bounded name
 pub type Name = BoundedVec<u8, ConstU32<32>>;
@@ -61,9 +62,13 @@ pub struct MurmurProxyDetails<AccountId> {
 	/// The proxy account address
 	pub address: AccountId,
 	/// The MMR root
-	pub root: Vec<u8>,
+	pub root: BoundedVec<u8, ConstU32<32>>,
 	/// The MMR size
 	pub size: u64,
+	/// The serialized VRF pubkey
+	pub pubkey: BoundedVec<u8, ConstU32<48>>,
+	/// The nonce of the Murmur proxy
+	pub nonce: u64,
 }
 
 #[frame_support::pallet]
@@ -101,8 +106,9 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		OtpProxyCreated,
-		OtpProxyExecuted,
+		MurmurProxyCreated,
+		MurmurProxyExecuted,
+		MurmurProxyUpdated,
 	}
 
 	// Errors inform users that something went wrong.
@@ -112,6 +118,10 @@ pub mod pallet {
 		DuplicateName,
 		InvalidOTP,
 		InvalidMerkleProof,
+		/// The Schnorr proof could not be verified
+		SchnorrProofVerificationFailed,
+		/// https://crypto.stanford.edu/cs355/19sp/lec5.pdf
+		InvalidSchnorrProof,
 		InvalidProxy,
 		ProxyDNE,
 	}
@@ -123,17 +133,22 @@ pub mod pallet {
 		/// * `root`: The MMR root
 		/// * `size`: The size (number of leaves) of the MMR
 		/// * `name`: The name to assign to the murmur proxy
+		/// * `proof`: A (serialized) DLEQ proof
+		/// * `public_key`: A (serialized) public key associated with the DLEQ
+		///
 		#[pallet::weight(0)]
 		#[pallet::call_index(0)]
 		pub fn create(
 			origin: OriginFor<T>,
-			root: Vec<u8>,
+			root: BoundedVec<u8, ConstU32<32>>,
 			size: u64,
 			name: BoundedVec<u8, ConstU32<32>>,
+			proof: BoundedVec<u8, ConstU32<80>>,
+			pubkey: BoundedVec<u8, ConstU32<48>>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
-			// check duplicate name
+			// ensure unique names
 			ensure!(Registry::<T>::get(name.clone()).is_none(), Error::<T>::DuplicateName);
 
 			// create a pure proxy with no delegate
@@ -148,10 +163,63 @@ pub mod pallet {
 			)?;
 
 			let address =
-				pallet_proxy::Pallet::<T>::pure_account(&who, &T::ProxyType::default(), 0, None);
+				pallet_proxy::Pallet::<T>::pure_account(
+					&who, &T::ProxyType::default(), 0, None);
 
-			Registry::<T>::insert(name, &MurmurProxyDetails { address, root, size });
-			Self::deposit_event(Event::OtpProxyCreated);
+			let nonce = 0;
+
+			let validity = verify_update::<TinyBLS377>(
+				proof.to_vec(), 
+				pubkey.to_vec(), 
+				nonce,
+			).map_err(|_| Error::<T>::SchnorrProofVerificationFailed)?;
+
+			ensure!(validity, Error::<T>::InvalidSchnorrProof);
+
+			Registry::<T>::insert(
+				name,
+				&MurmurProxyDetails { address, root, size, pubkey, nonce },
+			);
+			Self::deposit_event(Event::MurmurProxyCreated);
+
+			Ok(())
+		}
+
+		/// Update the MMR associated with a Murmur proxy
+		/// Does not require a signed origin
+		///
+		/// * `root`: The MMR root
+		/// * `size`: The size (number of leaves) of the MMR
+		/// * `name`: The name to assign to the murmur proxy
+		/// * `proof`: A (serialized) DLEQ proof
+		/// * `public_key`: A (serialized) public key associated with the DLEQ
+		///
+		#[pallet::weight(0)]
+		#[pallet::call_index(1)]
+		pub fn update(
+			_origin: OriginFor<T>,
+			name: BoundedVec<u8, ConstU32<32>>,
+			new_root: BoundedVec<u8, ConstU32<32>>,
+			new_size: u64,
+			proof: BoundedVec<u8, ConstU32<48>>
+		) -> DispatchResult {
+			// let who = ensure_signed(origin)?;
+			let proxy_details = Registry::<T>::get(name.clone())
+				.ok_or(Error::<T>::InvalidProxy)?;
+			// verify the proof
+			let next_nonce = proxy_details.nonce + 1;
+			let validity = 
+				verify_update::<TinyBLS377>(proof.to_vec(), proxy_details.pubkey.to_vec(), next_nonce)
+					.map_err(|_| Error::<T>::SchnorrProofVerificationFailed)?;
+			ensure!(validity, Error::<T>::InvalidSchnorrProof);
+			// update proxy details
+			let mut new_proxy_details = proxy_details.clone();
+			new_proxy_details.root = new_root;
+			new_proxy_details.size = new_size;
+			new_proxy_details.nonce = next_nonce;
+
+			Registry::<T>::insert(name, &new_proxy_details);
+			Self::deposit_event(Event::MurmurProxyUpdated);
 
 			Ok(())
 		}
@@ -169,8 +237,9 @@ pub mod pallet {
 		///   position
 		/// * `size`: The size of the Merkle proof
 		/// * `call`: The call to be proxied
+		///
 		#[pallet::weight(0)]
-		#[pallet::call_index(1)]
+		#[pallet::call_index(2)]
 		pub fn proxy(
 			_origin: OriginFor<T>,
 			name: BoundedVec<u8, ConstU32<32>>,
@@ -183,23 +252,29 @@ pub mod pallet {
 		) -> DispatchResult {
 			let when = T::TlockProvider::latest();
 
-			let proxy_details = Registry::<T>::get(name.clone()).ok_or(Error::<T>::InvalidProxy)?;
+			let proxy_details = Registry::<T>::get(name.clone())
+				.ok_or(Error::<T>::InvalidProxy)?;
 
 			let result = T::TlockProvider::decrypt_at(&ciphertext, when)
 				.map_err(|_| Error::<T>::BadCiphertext)?;
+
 			let otp = result.message;
 
-			let leaves: Vec<Leaf> = proof.clone().into_iter().map(|p| Leaf(p)).collect::<Vec<_>>();
-			let merkle_proof = MerkleProof::<Leaf, MergeLeaves>::new(size, leaves.clone());
-			let root = Leaf(proxy_details.root);
+			let leaves: Vec<Leaf> = 
+				proof.clone().into_iter().map(|p| Leaf(p)).collect::<Vec<_>>();
+				
+			let merkle_proof = 
+				MerkleProof::<Leaf, MergeLeaves>::new(size, leaves.clone());
 
-			let validity = murmur::verify(
+			let root = Leaf(proxy_details.root.to_vec() );
+
+			let validity = verify_execute(
 				root,
 				merkle_proof,
 				hash,
 				ciphertext,
-				otp,
-				call.encode().to_vec(),
+				&otp,
+				&call.encode(),
 				position,
 			);
 
@@ -214,7 +289,7 @@ pub mod pallet {
 
 			pallet_proxy::Pallet::<T>::do_proxy(def, proxy_details.address, *call);
 
-			Self::deposit_event(Event::OtpProxyExecuted);
+			Self::deposit_event(Event::MurmurProxyExecuted);
 			Ok(())
 		}
 	}

--- a/pallets/murmur/src/lib.rs
+++ b/pallets/murmur/src/lib.rs
@@ -275,10 +275,6 @@ pub mod pallet {
 
 			let root = Leaf(proxy_details.root.to_vec() );
 
-			if !merkle_proof.verify(root.clone(), vec![(position, Leaf(ciphertext.clone()))]).unwrap() {
-				panic!("huh");
-			}
-
 			let validity = verify_execute(
 				root,
 				merkle_proof,

--- a/pallets/murmur/src/lib.rs
+++ b/pallets/murmur/src/lib.rs
@@ -202,17 +202,23 @@ pub mod pallet {
 			_origin: OriginFor<T>,
 			name: BoundedVec<u8, ConstU32<32>>,
 			new_root: BoundedVec<u8, ConstU32<32>>,
+			proof: BoundedVec<u8, ConstU32<80>>,
 			new_size: u64,
-			proof: BoundedVec<u8, ConstU32<80>>
 		) -> DispatchResult {
 			// let who = ensure_signed(origin)?;
 			let proxy_details = Registry::<T>::get(name.clone())
 				.ok_or(Error::<T>::InvalidProxy)?;
 			// verify the proof
 			let next_nonce = proxy_details.nonce + 1;
-			let validity = 
-				verify_update::<TinyBLS377>(proof.to_vec(), proxy_details.pubkey.to_vec(), next_nonce)
-					.map_err(|_| Error::<T>::SchnorrProofVerificationFailed)?;
+
+			// panic!("{:?}, {:?}, {:?}", proof.to_vec(), proxy_details.pubkey.to_vec(), next_nonce);
+
+			let validity = verify_update::<TinyBLS377>(
+				proof.to_vec(), 
+				proxy_details.pubkey.to_vec(), 
+				next_nonce
+			).map_err(|_| Error::<T>::SchnorrProofVerificationFailed)?;
+			
 			ensure!(validity, Error::<T>::InvalidSchnorrProof);
 			// update proxy details
 			let mut new_proxy_details = proxy_details.clone();

--- a/pallets/murmur/src/lib.rs
+++ b/pallets/murmur/src/lib.rs
@@ -108,24 +108,31 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
+		/// A murmur proxy was created
 		MurmurProxyCreated,
+		/// A murmur proxy was execute
 		MurmurProxyExecuted,
+		/// A murmur proxy was updated
 		MurmurProxyUpdated,
 	}
 
 	// Errors inform users that something went wrong.
 	#[pallet::error]
 	pub enum Error<T> {
+		/// The ciphertext could not be recovered
 		BadCiphertext,
+		/// The input name is already used
 		DuplicateName,
+		/// The OTP code is invalid
 		InvalidOTP,
+		/// The Merkle proof could not be verified
 		InvalidMerkleProof,
 		/// The Schnorr proof could not be verified
 		SchnorrProofVerificationFailed,
 		/// https://crypto.stanford.edu/cs355/19sp/lec5.pdf
 		InvalidSchnorrProof,
+		/// The proxy is not registered as a Murmur wallet or does not exist 
 		InvalidProxy,
-		ProxyDNE,
 	}
 
 	#[pallet::call]

--- a/pallets/murmur/src/lib.rs
+++ b/pallets/murmur/src/lib.rs
@@ -211,8 +211,6 @@ pub mod pallet {
 			// verify the proof
 			let next_nonce = proxy_details.nonce + 1;
 
-			// panic!("{:?}, {:?}, {:?}", proof.to_vec(), proxy_details.pubkey.to_vec(), next_nonce);
-
 			let validity = verify_update::<TinyBLS377>(
 				proof.to_vec(), 
 				proxy_details.pubkey.to_vec(), 
@@ -258,15 +256,16 @@ pub mod pallet {
 			size: u64,
 			call: sp_std::boxed::Box<<T as pallet_proxy::Config>::RuntimeCall>,
 		) -> DispatchResult {
-			// let when = T::TlockProvider::latest();
+
+			let when = T::TlockProvider::latest();
 
 			let proxy_details = Registry::<T>::get(name.clone())
 				.ok_or(Error::<T>::InvalidProxy)?;
 
-			// let result = T::TlockProvider::decrypt_at(&ciphertext, when)
-			// 	.map_err(|_| Error::<T>::BadCiphertext)?;
+			let result = T::TlockProvider::decrypt_at(&ciphertext, when)
+				.map_err(|_| Error::<T>::BadCiphertext)?;
 
-			// let otp = result.message;
+			let otp = result.message;
 
 			let leaves: Vec<Leaf> = 
 				proof.clone().into_iter().map(|p| Leaf(p)).collect::<Vec<_>>();
@@ -280,28 +279,28 @@ pub mod pallet {
 				panic!("huh");
 			}
 
-			// let validity = verify_execute(
-			// 	root,
-			// 	merkle_proof,
-			// 	hash,
-			// 	ciphertext,
-			// 	&otp,
-			// 	&call.encode(),
-			// 	position,
-			// );
+			let validity = verify_execute(
+				root,
+				merkle_proof,
+				hash,
+				ciphertext,
+				&otp,
+				&call.encode(),
+				position,
+			);
 
-			// frame_support::ensure!(validity, Error::<T>::InvalidMerkleProof);
+			frame_support::ensure!(validity, Error::<T>::InvalidMerkleProof);
 
-			// let def = pallet_proxy::Pallet::<T>::find_proxy(
-			// 	&proxy_details.address,
-			// 	None,
-			// 	Some(T::ProxyType::default()),
-			// )
-			// .map_err(|_| Error::<T>::InvalidProxy)?;
+			let def = pallet_proxy::Pallet::<T>::find_proxy(
+				&proxy_details.address,
+				None,
+				Some(T::ProxyType::default()),
+			)
+			.map_err(|_| Error::<T>::InvalidProxy)?;
 
-			// pallet_proxy::Pallet::<T>::do_proxy(def, proxy_details.address, *call);
+			pallet_proxy::Pallet::<T>::do_proxy(def, proxy_details.address, *call);
 
-			// Self::deposit_event(Event::MurmurProxyExecuted);
+			Self::deposit_event(Event::MurmurProxyExecuted);
 			Ok(())
 		}
 	}

--- a/pallets/murmur/src/mock.rs
+++ b/pallets/murmur/src/mock.rs
@@ -19,12 +19,12 @@ use std::vec;
 
 use crate as pallet_murmur;
 use codec::Encode;
-use etf_crypto_primitives::encryption::tlock::DecryptionResult;
+use ark_serialize::CanonicalDeserialize;
+use etf_crypto_primitives::encryption::tlock::{DecryptionResult, TLECiphertext};
 use frame_support::{
 	construct_runtime, derive_impl, parameter_types,
 	traits::{ConstU128, ConstU32, ConstU64, InstanceFilter},
 };
-use murmur_test_utils::{BOTPGenerator, generate_witness, otp};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 use sha3::Digest;
@@ -39,6 +39,7 @@ use sp_runtime::{
 };
 use sp_state_machine::BasicExternalities;
 use w3f_bls::TinyBLS377;
+use ark_transcript::{digest::Update, Transcript};
 
 pub use sp_consensus_beefy_etf::bls_crypto::AuthorityId as BeefyId;
 
@@ -87,13 +88,25 @@ impl pallet_balances::Config for Test {
 pub struct DummyTlockProvider;
 impl TimelockEncryptionProvider<u64> for DummyTlockProvider {
 	fn decrypt_at(
-		_bytes: &[u8],
+		bytes: &[u8],
 		when: u64,
 	) -> Result<DecryptionResult, pallet_randomness_beacon::TimelockError> {
 		let seed = vec![1,2,3];
-		let mut rng = ChaCha20Rng::seed_from_u64(0);
-		let otp = otp::<TinyBLS377, ChaCha20Rng>(seed, 10, &mut rng);
-		Ok(DecryptionResult { message: otp, secret: [2; 32] })
+
+		let mut transcript = Transcript::new_labeled(murmur_core::murmur::MURMUR_PROTO_OTP);
+		transcript.write_bytes(&seed);
+		let nonce: u64 = 0;
+		transcript.write_bytes(&nonce.to_be_bytes());
+	
+		let ephemeral_msk: Vec<u8> = vec![10, 124, 150, 208, 196, 211, 212, 13, 177, 116, 154, 11, 235, 242, 139, 2, 187, 80, 52, 58, 125, 72, 184, 194, 165, 119, 212, 134, 171, 185, 191, 101];
+
+		let ciphertext: TLECiphertext<TinyBLS377> =
+			TLECiphertext::deserialize_compressed(&mut &bytes[..]).unwrap();
+
+		let otp = ciphertext
+			.aes_decrypt(ephemeral_msk.as_slice().to_vec()).unwrap();
+
+		Ok(DecryptionResult { message: otp.message, secret: [2; 32] })
 	}
 
 	fn latest() -> u64 {

--- a/pallets/murmur/src/tests.rs
+++ b/pallets/murmur/src/tests.rs
@@ -199,7 +199,7 @@ fn it_can_proxy_valid_calls() {
 		let bounded_root = BoundedVec::<u8, ConstU32<32>>::truncate_from(root.0);
 		let bounded_pubkey = BoundedVec::<u8, ConstU32<48>>::truncate_from(mmr_store.public_key.clone());
 		let bounded_proof = BoundedVec::<u8, ConstU32<80>>::truncate_from(mmr_store.proof.clone());
-
+	
 		assert_ok!(Murmur::create(
 			RuntimeOrigin::signed(0),
 			bounded_root.clone(),
@@ -223,18 +223,18 @@ fn it_can_proxy_valid_calls() {
 			vec![sig_bytes_1.to_vec()],
 			WHEN,
 		));
-		
+
 		let call = call_remark(vec![1, 2, 3, 4, 5]);
-		let (proof, commitment, ciphertext, pos) = mmr_store
+		let (merkle_proof, commitment, ciphertext, pos) = mmr_store
 			.execute(
 				SEED.to_vec().clone(), 
-				WHEN.clone() as u32, 
+				WHEN.clone() as u32,
 				call.encode().to_vec(), 
 				&mut rng
 			).unwrap();
 
 		let proof_items: Vec<Vec<u8>> =
-			proof.proof_items().iter().map(|leaf| leaf.0.to_vec()).collect::<Vec<_>>();
+			merkle_proof.proof_items().iter().map(|leaf| leaf.0.to_vec()).collect::<Vec<_>>();
 
 		assert_ok!(Murmur::proxy(
 			RuntimeOrigin::signed(0),
@@ -243,7 +243,7 @@ fn it_can_proxy_valid_calls() {
 			commitment,
 			ciphertext,
 			proof_items,
-			size,
+			merkle_proof.mmr_size(),
 			Box::new(call),
 		));
 	});

--- a/pallets/murmur/src/tests.rs
+++ b/pallets/murmur/src/tests.rs
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-use crate::{self as murmur, mock::*};
+use crate::{self as murmur, mock::*, Error, Call, Config};
 use codec::Encode;
-use frame_support::{assert_ok, traits::ConstU32, BoundedVec};
+use frame_support::{assert_ok, assert_noop, traits::ConstU32, BoundedVec};
 use frame_system::Call as SystemCall;
 use murmur_core::types::{BlockNumber, Identity, IdentityBuilder};
 use murmur_test_utils::MurmurStore;
-use sp_consensus_beefy_etf::{known_payloads, Commitment, Payload};
+use sp_consensus_beefy_etf::{known_payloads, Commitment, Payload, ValidatorSetId};
+use sp_core::{bls377, ByteArray, Pair};
 use w3f_bls::{DoublePublicKey, SerializableToBytes, TinyBLS377};
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use murmur_core::{
+	murmur::verifier::{verify_execute, verify_update},
+	types::{Leaf, MergeLeaves},
+};
 
 #[derive(Debug)]
 pub struct BasicIdBuilder;
@@ -38,13 +45,32 @@ impl IdentityBuilder<BlockNumber> for BasicIdBuilder {
 	}
 }
 
+/*
+Test Contants
+*/
+pub const BLOCK_SCHEDULE: &[BlockNumber] = &[
+	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+];
+pub const WHEN: u64 = 10;
+pub const OTP: &[u8] = b"823185";
+pub const SEED: &[u8] = &[1, 2, 3];
+
+fn calculate_signature(
+	id: u8,
+	serialized_resharing: &[u8],
+	message: &[u8],
+) -> (bls377::Public, bls377::Signature) {
+	let kp = sp_core::bls::Pair::from_seed_slice(&[id; 32]).unwrap();
+	let etf_kp = kp.acss_recover(serialized_resharing, 1).unwrap();
+	(etf_kp.public(), etf_kp.sign(message))
+}
+
 #[test]
 fn it_can_create_new_proxy_with_unique_name() {
 	let seed = b"seed".to_vec();
 	let unique_name = b"name".to_vec();
 	let bounded_name = BoundedVec::<u8, ConstU32<32>>::truncate_from(unique_name);
 	let block_schedule = vec![1, 2, 3];
-	let ephem_msk = [3; 32];
 
 	let size = 3;
 
@@ -52,64 +78,160 @@ fn it_can_create_new_proxy_with_unique_name() {
 		let round_pubkey_bytes = Etf::round_pubkey().to_vec();
 		let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
 
-		let mmr_store = MurmurStore::new::<TinyBLS377, BasicIdBuilder>(
+		let mut rng = ChaCha20Rng::seed_from_u64(0);
+
+		let mmr_store = MurmurStore::new::<TinyBLS377, BasicIdBuilder, ChaCha20Rng>(
 			seed.clone().into(),
 			block_schedule.clone(),
-			ephem_msk,
+			0,
 			round_pubkey,
-		);
+			&mut rng,
+		).unwrap();
+
+		// sanity check
+		let validity = verify_update::<TinyBLS377>(
+			mmr_store.proof.clone(), 
+			mmr_store.public_key.clone(), 
+			0,
+		).unwrap();
+
+		assert!(validity);
+
 		let root = mmr_store.root.clone();
+
+		let bounded_root = BoundedVec::<u8, ConstU32<32>>::truncate_from(root.0);
+		let bounded_pubkey = BoundedVec::<u8, ConstU32<48>>::truncate_from(mmr_store.public_key);
+		let bounded_proof = BoundedVec::<u8, ConstU32<80>>::truncate_from(mmr_store.proof);
+
 		assert_ok!(Murmur::create(
 			RuntimeOrigin::signed(0),
-			root.0.to_vec(),
+			bounded_root,
 			size,
 			bounded_name.clone(),
+			bounded_proof.clone(),
+			bounded_pubkey.clone(),
 		));
 
 		// check storage
 		let registered_proxy = murmur::Registry::<Test>::get(bounded_name.clone());
 		assert!(registered_proxy.is_some());
+
+		// verify that the proxy exists
 	});
 }
 
 #[test]
-fn it_can_proxy_valid_calls() {
+fn it_fails_to_create_new_proxy_with_duplicate_name() {
 	let seed = b"seed".to_vec();
 	let unique_name = b"name".to_vec();
 	let bounded_name = BoundedVec::<u8, ConstU32<32>>::truncate_from(unique_name);
-	let when = 1;
 	let block_schedule = vec![1, 2, 3];
-	let ephem_msk = [3; 32];
+
 	let size = 3;
 
 	new_test_ext(vec![0]).execute_with(|| {
 		let round_pubkey_bytes = Etf::round_pubkey().to_vec();
 		let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
 
-		let mmr_store = MurmurStore::new::<TinyBLS377, BasicIdBuilder>(
+		let mut rng = ChaCha20Rng::seed_from_u64(0);
+		
+		let mmr_store = MurmurStore::new::<TinyBLS377, BasicIdBuilder, ChaCha20Rng>(
 			seed.clone().into(),
 			block_schedule.clone(),
-			ephem_msk,
+			0,
 			round_pubkey,
-		);
+			&mut rng,
+		).unwrap();
 
 		let root = mmr_store.root.clone();
+		let bounded_root = BoundedVec::<u8, ConstU32<32>>::truncate_from(root.0);
+		let bounded_pubkey = BoundedVec::<u8, ConstU32<48>>::truncate_from(mmr_store.public_key);
+		let bounded_proof = BoundedVec::<u8, ConstU32<80>>::truncate_from(mmr_store.proof);
+
 		assert_ok!(Murmur::create(
 			RuntimeOrigin::signed(0),
-			root.0.to_vec(),
+			bounded_root.clone(),
 			size,
 			bounded_name.clone(),
+			bounded_proof.clone(),
+			bounded_pubkey.clone(),
 		));
 
-		// the beacon would write a new pulse here, but we will mock it instead
-		// but here, we can just generate the expected OTP code when we mock decryption
+		// check storage
+		let registered_proxy = murmur::Registry::<Test>::get(bounded_name.clone());
+		assert!(registered_proxy.is_some());
 
-		// now we want to proxy a call
+
+		assert_noop!(Murmur::create(
+			RuntimeOrigin::signed(0),
+			bounded_root,
+			size,
+			bounded_name.clone(),
+			bounded_proof.clone(),
+			bounded_pubkey.clone(),
+		), Error::<Test>::DuplicateName);
+
+		// verify that the proxy exists
+	});
+}
+
+#[test]
+fn it_can_proxy_valid_calls() {
+	let unique_name = b"name".to_vec();
+	let bounded_name = BoundedVec::<u8, ConstU32<32>>::truncate_from(unique_name);
+	let size = BLOCK_SCHEDULE.len() as u64;
+
+	new_test_ext(vec![0]).execute_with(|| {
+		let round_pubkey_bytes = Etf::round_pubkey().to_vec();
+		let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
+
+		let mut rng = ChaCha20Rng::seed_from_u64(0);
+		
+		let mmr_store = MurmurStore::new::<TinyBLS377, BasicIdBuilder, ChaCha20Rng>(
+			SEED.clone().to_vec(),
+			BLOCK_SCHEDULE.to_vec().clone(),
+			0,
+			round_pubkey,
+			&mut rng,
+		).unwrap();
+
+		let root = mmr_store.root.clone();
+		let bounded_root = BoundedVec::<u8, ConstU32<32>>::truncate_from(root.0);
+		let bounded_pubkey = BoundedVec::<u8, ConstU32<48>>::truncate_from(mmr_store.public_key.clone());
+		let bounded_proof = BoundedVec::<u8, ConstU32<80>>::truncate_from(mmr_store.proof.clone());
+
+		assert_ok!(Murmur::create(
+			RuntimeOrigin::signed(0),
+			bounded_root.clone(),
+			size,
+			bounded_name.clone(),
+			bounded_proof.clone(),
+			bounded_pubkey.clone(),
+		));
+
+		// now we write a new pulse
+		let resharing_bytes_1 = &pallet_etf::Shares::<Test>::get()[0];
+		let payload = Payload::from_single_entry(known_payloads::ETF_SIGNATURE, Vec::new());
+		let validator_set_id = 0;
+		let commitment = Commitment { payload, block_number: WHEN, validator_set_id };
+		let (_pk1, signature_1) = calculate_signature(0, resharing_bytes_1, &commitment.encode());
+		let sig_bytes_1: &[u8] = signature_1.as_ref();
+
+		// now we write a pulse of randomness to the beacon pallet
+		assert_ok!(RandomnessBeacon::write_pulse(
+			RuntimeOrigin::none(),
+			vec![sig_bytes_1.to_vec()],
+			WHEN,
+		));
+		
 		let call = call_remark(vec![1, 2, 3, 4, 5]);
-		// We want to use the ciphertext for block = 1
 		let (proof, commitment, ciphertext, pos) = mmr_store
-			.execute(seed.clone(), when.clone() as u32, call.encode().to_vec())
-			.unwrap();
+			.execute(
+				SEED.to_vec().clone(), 
+				WHEN.clone() as u32, 
+				call.encode().to_vec(), 
+				&mut rng
+			).unwrap();
 
 		let proof_items: Vec<Vec<u8>> =
 			proof.proof_items().iter().map(|leaf| leaf.0.to_vec()).collect::<Vec<_>>();

--- a/pallets/murmur/src/tests.rs
+++ b/pallets/murmur/src/tests.rs
@@ -102,8 +102,6 @@ fn it_can_create_new_proxy_with_unique_name() {
 		// check storage
 		let registered_proxy = murmur::Registry::<Test>::get(bounded_name.clone());
 		assert!(registered_proxy.is_some());
-
-		// verify that the proxy exists
 	});
 }
 
@@ -174,8 +172,6 @@ fn it_can_update_proxy() {
 		let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
 		let same_round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
 
-		// assert_eq!(round_pubkey, same_round_pubkey);
-
 		let mut rng = ChaCha20Rng::seed_from_u64(0);
 
 		let mmr_store = MurmurStore::<EngineTinyBLS377>::new::<BasicIdBuilder, ChaCha20Rng>(
@@ -226,8 +222,6 @@ fn it_can_update_proxy() {
 		let second_root = another_murmur_store.root.clone();
 		let second_bounded_root = BoundedVec::<u8, ConstU32<32>>::truncate_from(second_root.0);
 		let second_bounded_proof = BoundedVec::<u8, ConstU32<80>>::truncate_from(another_proof.clone());
-		// let second_bounded_pubkey = BoundedVec::<u8, ConstU32<48>>::truncate_from(second_mmr_store.public_key);
-		
 		
 		assert_ok!(Murmur::update(
 			RuntimeOrigin::signed(0),

--- a/primitives/consensus/beefy-etf/Cargo.toml
+++ b/primitives/consensus/beefy-etf/Cargo.toml
@@ -28,10 +28,14 @@ sp-runtime = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = 
 sp-keystore = { git = "https://github.com/ideal-lab5/polkadot-sdk.git", branch = "testing", default-features = false }
 strum = { version = "0.24.1", features = ["derive"], default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
+ark-std = { version = "0.4.0", default-features = false }
+ark-serialize = { version = "0.4.0", default-features = false }
+rand = {version = "0.8", default-features = false }
+w3f-bls = {version = "0.1.3", default-features = false }
+etf-crypto-primitives = { git = "https://github.com/ideal-lab5/etf-sdk.git", branch = "tony/dev", default-features = false}
 
 [dev-dependencies]
 array-bytes = "6.1"
-w3f-bls = { version = "0.1.3", features = ["std"] }
 
 [features]
 default = ["std"]
@@ -49,6 +53,11 @@ std = [
 	"sp-mmr-primitives/std",
 	"sp-runtime/std",
 	"strum/std",
+	"ark-std/std",
+	"ark-serialize/std",
+	"rand/std",
+	"w3f-bls/std",
+	"etf-crypto-primitives/std"
 ]
 
 # Serde support without relying on std features.

--- a/primitives/consensus/beefy-etf/src/test_utils.rs
+++ b/primitives/consensus/beefy-etf/src/test_utils.rs
@@ -19,15 +19,24 @@
 // use crate::bls_bls_crypto;
 use crate::{
 	bls_crypto, AuthorityIdBound, BeefySignatureHasher, Commitment, EquivocationProof, Payload,
-	ValidatorSetId, VoteMessage,
+	ValidatorSetId, VoteMessage, bls_crypto::{AuthorityId as BeefyId},
 };
-use sp_application_crypto::{AppCrypto, AppPair, RuntimeAppPublic, Wraps};
+use sp_application_crypto::{AppCrypto, AppPair, RuntimeAppPublic, Wraps, UncheckedFrom};
 use sp_core::{bls377, Pair};
 use sp_runtime::traits::Hash;
 
 use codec::Encode;
 use std::{collections::HashMap, marker::PhantomData};
 use strum::IntoEnumIterator;
+
+use ark_serialize::CanonicalSerialize;
+use ark_std::UniformRand;
+use etf_crypto_primitives::{
+	proofs::hashed_el_gamal_sigma::BatchPoK,
+	dpss::acss::DoubleSecret
+};
+use rand::rngs::OsRng;
+use w3f_bls::{DoublePublicKey, DoublePublicKeyScheme, EngineBLS, SerializableToBytes, TinyBLS377};
 
 /// Set of test accounts using [`crate::bls_crypto`] types.
 #[allow(missing_docs)]
@@ -159,4 +168,57 @@ pub fn generate_equivocation_proof(
 	let first = signed_vote(vote1.0, vote1.1, vote1.2, vote1.3);
 	let second = signed_vote(vote2.0, vote2.1, vote2.2, vote2.3);
 	EquivocationProof { first, second }
+}
+
+/// Helper function to prepare initial secrets and resharing for ETF conensus
+/// return a vec of (authority id, resharing, pubkey commitment) along with ibe public key against the master secret
+pub fn etf_genesis<E: EngineBLS>(
+	initial_authorities: Vec<BeefyId>,
+) -> (Vec<u8>, Vec<(BeefyId, Vec<u8>)>) {
+	let msk_prime = E::Scalar::rand(&mut OsRng);
+	let keypair = w3f_bls::KeypairVT::<E>::generate(&mut OsRng);
+	let msk: E::Scalar = keypair.secret.0;
+	let double_public: DoublePublicKey<E> =
+		DoublePublicKey(keypair.into_public_key_in_signature_group().0, keypair.public.0);
+
+	let double_secret = DoubleSecret::<E>(msk, msk_prime);
+
+	let mut double_public_bytes = Vec::new();
+	double_public.serialize_compressed(&mut double_public_bytes).unwrap();
+
+	let genesis_resharing: Vec<(DoublePublicKey<E>, BatchPoK<E::PublicKeyGroup>)> = double_secret
+		.reshare(
+			&initial_authorities
+				.iter()
+				.map(|authority| {
+					w3f_bls::single::PublicKey::<E>(
+						w3f_bls::double::DoublePublicKey::<E>::from_bytes(&authority.to_raw_vec())
+							.unwrap()
+							.1,
+					)
+				})
+				.collect::<Vec<_>>(),
+			initial_authorities.len() as u8, // threshold = full set of authorities for now
+			&mut OsRng,
+		)
+		.unwrap();
+
+	let serialized_resharings = initial_authorities
+		.iter()
+		.enumerate()
+		.map(|(idx, _)| {
+			let pk = &genesis_resharing[idx].0;
+			let mut pk_bytes = [0u8; 144];
+			pk.serialize_compressed(&mut pk_bytes[..]).unwrap();
+			let blspk = bls377::Public::unchecked_from(pk_bytes);
+
+			let pok = &genesis_resharing[idx].1;
+			let mut bytes = Vec::new();
+			pok.serialize_compressed(&mut bytes).unwrap();
+
+			let beefy_id = BeefyId::from(blspk);
+			(beefy_id, bytes)
+		})
+		.collect::<Vec<_>>();
+	(double_public_bytes, serialized_resharings)
 }

--- a/primitives/consensus/beefy-etf/src/witness.rs
+++ b/primitives/consensus/beefy-etf/src/witness.rs
@@ -90,7 +90,7 @@ mod tests {
 	#[cfg(feature = "bls-experimental")]
 	use w3f_bls::{
 		single_pop_aggregator::SignatureAggregatorAssumingPoP, Message, SerializableToBytes,
-		Signed, Tinybls381,
+		Signed, TinyBLS381,
 	};
 
 	type TestCommitment = Commitment<u128>;
@@ -198,7 +198,7 @@ mod tests {
 			// from signed take a function as the aggregator 
 			TestBlsSignedCommitmentWitness::from_signed::<_, _>(signed, |sigs| {
 				// we are going to aggregate the signatures here
-				let mut aggregatedsigs: SignatureAggregatorAssumingPoP<Tinybls381> =
+				let mut aggregatedsigs: SignatureAggregatorAssumingPoP<TinyBLS381> =
 					SignatureAggregatorAssumingPoP::new(Message::new(b"", b"mock payload"));
 
 				for sig in sigs {
@@ -206,7 +206,7 @@ mod tests {
 						Some(sig) => {
 							let serialized_sig : Vec<u8> = (*sig.1).to_vec();
 							aggregatedsigs.add_signature(
-								&w3f_bls::Signature::<Tinybls381>::from_bytes(
+								&w3f_bls::Signature::<TinyBLS381>::from_bytes(
 									serialized_sig.as_slice()
 								).unwrap()
 							);
@@ -219,7 +219,7 @@ mod tests {
 
 		// We can't use BlsSignature::try_from because it expected 112Bytes (CP (64) + BLS 48)
 		// single signature while we are having a BLS aggregated signature corresponding to no CP.
-		w3f_bls::Signature::<Tinybls381>::from_bytes(witness.signature_accumulator.as_slice())
+		w3f_bls::Signature::<TinyBLS381>::from_bytes(witness.signature_accumulator.as_slice())
 			.unwrap();
 	}
 


### PR DESCRIPTION
- closes #15 

This adds support for:
- storing VRF pubkeys on murmur creation 
- updating murmur wallets

It adds an 'update' extrinsic that verifies DLEQ proofs prior to allowing updates to the murmur proxy details, proving the caller knows the original seed.

In addition:
- adds more in-depth testing to the murmur pallet
- uses BoundedVec in place of Vec
- updates error names (Murmur instead of OTP)
