### PR TITLE
[Drand pallet] `random_at` to return an Option + formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       -   id: fmt
           name: fmt
           description: Format files with cargo fmt.
-          entry: cargo +nightly fmt --
+          entry: cargo +nightly fmt -- --check
           language: system
           files: \.rs$
           args: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,10 @@
 repos:
   - repo: local
     hooks:
-      - id: cargo-fmt
-        name: Cargo Fmt
-        entry: cargo +nightly fmt -- --check
-        language: system
-        types: [rust]
+      -   id: fmt
+          name: fmt
+          description: Format files with cargo fmt.
+          entry: cargo +nightly fmt --
+          language: system
+          files: \.rs$
+          args: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 repos:
-  - repo: https://github.com/doublify/pre-commit-rust
-    rev: v1.0
+  - repo: local
     hooks:
-      - id: fmt
+      - id: cargo-fmt
+        name: Cargo Fmt
+        entry: cargo +nightly fmt -- --check
+        language: system
+        types: [rust]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-transcript"
+version = "0.0.2"
+source = "git+https://github.com/w3f/ring-vrf.git#0fef8266d851932ad25d6b41bc4b34d834d1e11d"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+ "sha3",
+]
+
+[[package]]
 name = "array-bytes"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2123,33 @@ dependencies = [
  "chacha20poly1305",
  "generic-array 0.14.7",
  "log",
+ "parity-scale-codec",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3",
+ "w3f-bls 0.1.4",
+]
+
+[[package]]
+name = "etf-crypto-primitives"
+version = "0.2.4"
+source = "git+https://github.com/ideal-lab5/etf-sdk.git?branch=tony/dev#159ed603ca8a31b7d2e5f4437c62411c4d1fd743"
+dependencies = [
+ "aes-gcm",
+ "ark-bls12-377",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "array-bytes 6.2.3",
+ "chacha20poly1305",
+ "generic-array 0.14.7",
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
@@ -4939,7 +4979,6 @@ dependencies = [
 [[package]]
 name = "murmur-core"
 version = "0.1.0"
-source = "git+https://github.com/ideal-lab5/murmur.git?branch=dev#49f9d1e97c2d1b40dd88295c8cf4231cb408a2f3"
 dependencies = [
  "ark-bls12-377",
  "ark-serialize",
@@ -4958,7 +4997,6 @@ dependencies = [
 [[package]]
 name = "murmur-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/ideal-lab5/murmur.git?branch=dev#49f9d1e97c2d1b40dd88295c8cf4231cb408a2f3"
 dependencies = [
  "ark-serialize",
  "murmur-core",
@@ -5538,9 +5576,11 @@ dependencies = [
  "ark-bls12-381",
  "ark-serialize",
  "ark-std",
+ "ark-transcript 0.0.2 (git+https://github.com/w3f/ring-vrf.git)",
  "array-bytes 4.2.0",
  "binary-merkle-tree 15.0.1",
  "ckb-merkle-mountain-range",
+ "env_logger",
  "etf-crypto-primitives 0.2.4 (git+https://github.com/ideal-lab5/etf-sdk.git?branch=dev)",
  "frame-benchmarking 28.0.0",
  "frame-support 28.0.0",
@@ -5562,6 +5602,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "scale-info",
  "serde",
  "sha3",
@@ -8783,9 +8824,13 @@ dependencies = [
 name = "sp-consensus-beefy-etf"
 version = "13.0.0"
 dependencies = [
+ "ark-serialize",
+ "ark-std",
  "array-bytes 6.2.3",
+ "etf-crypto-primitives 0.2.4 (git+https://github.com/ideal-lab5/etf-sdk.git?branch=tony/dev)",
  "lazy_static",
  "parity-scale-codec",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "sp-api 26.0.0",

--- a/client/consensus/beefy-etf/src/communication/gossip.rs
+++ b/client/consensus/beefy-etf/src/communication/gossip.rs
@@ -156,13 +156,12 @@ impl<B: Block> Filter<B> {
 				f.start = cfg.start;
 				f.end = cfg.end;
 			},
-			_ => {
+			_ =>
 				self.inner = Some(FilterInner {
 					start: cfg.start,
 					end: cfg.end,
 					validator_set: cfg.validator_set.clone(),
-				})
-			},
+				}),
 		}
 	}
 

--- a/client/consensus/beefy-etf/src/justification.rs
+++ b/client/consensus/beefy-etf/src/justification.rs
@@ -36,9 +36,8 @@ pub(crate) fn proof_block_num_and_set_id<Block: BlockT>(
 	proof: &BeefyVersionedFinalityProof<Block>,
 ) -> (NumberFor<Block>, ValidatorSetId) {
 	match proof {
-		VersionedFinalityProof::V1(sc) => {
-			(sc.commitment.block_number, sc.commitment.validator_set_id)
-		},
+		VersionedFinalityProof::V1(sc) =>
+			(sc.commitment.block_number, sc.commitment.validator_set_id),
 	}
 }
 
@@ -63,9 +62,9 @@ pub(crate) fn verify_with_validator_set<Block: BlockT>(
 	let mut signatures_checked = 0u32;
 	match proof {
 		VersionedFinalityProof::V1(signed_commitment) => {
-			if signed_commitment.signatures.len() != validator_set.len()
-				|| signed_commitment.commitment.validator_set_id != validator_set.id()
-				|| signed_commitment.commitment.block_number != target_number
+			if signed_commitment.signatures.len() != validator_set.len() ||
+				signed_commitment.commitment.validator_set_id != validator_set.id() ||
+				signed_commitment.commitment.block_number != target_number
 			{
 				return Err((ConsensusError::InvalidJustification, 0));
 			}
@@ -106,9 +105,9 @@ pub(crate) fn verify_with_validator_set<Block: BlockT>(
 	let mut signatures_checked = 0u32;
 	match proof {
 		VersionedFinalityProof::V1(signed_commitment) => {
-			if signed_commitment.signatures.len() != validator_set.len()
-				|| signed_commitment.commitment.validator_set_id != validator_set.id()
-				|| signed_commitment.commitment.block_number != target_number
+			if signed_commitment.signatures.len() != validator_set.len() ||
+				signed_commitment.commitment.validator_set_id != validator_set.id() ||
+				signed_commitment.commitment.block_number != target_number
 			{
 				return Err((ConsensusError::InvalidJustification, 0));
 			}

--- a/client/consensus/beefy-etf/src/lib.rs
+++ b/client/consensus/beefy-etf/src/lib.rs
@@ -737,11 +737,10 @@ where
 				Some(active) => return Ok(active),
 				// Move up the chain. Ultimately we'll get it from chain genesis state, or error out
 				// there.
-				None => {
+				None =>
 					header = wait_for_parent_header(blockchain, header, HEADER_SYNC_DELAY)
 						.await
-						.map_err(|e| Error::Backend(e.to_string()))?
-				},
+						.map_err(|e| Error::Backend(e.to_string()))?,
 			}
 		}
 	}

--- a/client/consensus/beefy-etf/src/round.rs
+++ b/client/consensus/beefy-etf/src/round.rs
@@ -171,8 +171,8 @@ where
 
 		// add valid vote
 		let round = self.rounds.entry(vote.commitment.clone()).or_default();
-		if round.add_vote((vote.id, vote.signature))
-			&& round.is_done(threshold(self.validator_set.len()))
+		if round.add_vote((vote.id, vote.signature)) &&
+			round.is_done(threshold(self.validator_set.len()))
 		{
 			if let Some(round) = self.rounds.remove_entry(&vote.commitment) {
 				return VoteImportResult::RoundConcluded(self.signed_commitment(round));

--- a/client/consensus/beefy-etf/src/worker.rs
+++ b/client/consensus/beefy-etf/src/worker.rs
@@ -520,7 +520,7 @@ where
 	) -> Result<(), Error> {
 		let block_num = vote.commitment.block_number;
 		match self.voting_oracle().triage_round(block_num)? {
-			RoundAction::Process => {
+			RoundAction::Process =>
 				if let Some(finality_proof) = self.handle_vote(vote)? {
 					let gossip_proof = GossipMessage::<B>::FinalityProof(finality_proof);
 					let encoded_proof = gossip_proof.encode();
@@ -529,8 +529,7 @@ where
 						encoded_proof,
 						true,
 					);
-				}
-			},
+				},
 			RoundAction::Drop => metric_inc!(self.metrics, beefy_stale_votes),
 			RoundAction::Enqueue => error!(target: LOG_TARGET, "🥩 unexpected vote: {:?}.", vote),
 		};

--- a/pallets/drand/src/lib.rs
+++ b/pallets/drand/src/lib.rs
@@ -505,18 +505,10 @@ impl<T: Config> Pallet<T> {
 	/// get the randomness at a specific block height
 	/// returns None if it is invalid or does not exist
 	pub fn random_at(block_number: BlockNumberFor<T>) -> Option<RandomValue> {
-		match Pulses::<T>::get(block_number) {
-			Some(pulse) => {
-				let rand = pulse.randomness.into_inner();
-				if rand.len() == 32 {
-					let mut array = [0u8; 32];
-					array.copy_from_slice(&rand);
-					Some(array)
-				} else {
-					None // this should never happen
-				}
-			},
-			None => None,
+		if let Some(pulse) = Pulses::<T>::get(block_number) {
+			pulse.randomness.into_inner().try_into().ok()
+		} else {
+			None
 		}
 	}
 

--- a/pallets/drand/src/mock.rs
+++ b/pallets/drand/src/mock.rs
@@ -110,3 +110,12 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	.expect("Creating key with account Alice should succeed.");
 	ext
 }
+
+pub fn mock_pulse(randomness: Vec<u8>) -> Pulse {
+	Pulse {
+		round: 1,
+		randomness: BoundedVec::try_from(randomness).expect("Randomness should fit in BoundedVec"),
+		signature: BoundedVec::try_from(vec![0u8; 144])
+			.expect("Signature should fit in BoundedVec"),
+	}
+}

--- a/pallets/drand/src/tests.rs
+++ b/pallets/drand/src/tests.rs
@@ -325,3 +325,50 @@ fn can_execute_and_handle_valid_http_responses() {
 		assert_eq!(actual_pulse, DRAND_RESPONSE);
 	});
 }
+
+#[test]
+fn test_random_at_existing_pulse() {
+	new_test_ext().execute_with(|| {
+		// Set up the test environment
+		let block_number = 1;
+		let pulse = mock_pulse(vec![1; 32]);
+		Pulses::<Test>::insert(block_number, pulse);
+
+		// Call the function
+		let result = Drand::random_at(block_number);
+
+		// Check the result
+		assert_eq!(result, Some([1; 32]));
+	});
+}
+
+#[test]
+fn test_random_at_non_existing_pulse() {
+	new_test_ext().execute_with(|| {
+		// Set up the test environment
+		let block_number = 1;
+
+		// Call the function
+		let result = Drand::random_at(block_number);
+
+		// Check the result
+		assert_eq!(result, None);
+	});
+}
+
+#[test]
+fn test_random_at_invalid_pulse() {
+	new_test_ext().execute_with(|| {
+		// Set up the test environment
+		let block_number = 1;
+
+		let pulse = mock_pulse(vec![1; 31]); // Invalid length
+		Pulses::<Test>::insert(block_number, pulse);
+
+		// Call the function
+		let result = Drand::random_at(block_number);
+
+		// Check the result
+		assert_eq!(result, None);
+	});
+}

--- a/pallets/murmur/src/lib.rs
+++ b/pallets/murmur/src/lib.rs
@@ -147,7 +147,6 @@ pub mod pallet {
 		/// * `size`: The size (number of leaves) of the MMR
 		/// * `proof`: A (serialized) DLEQ proof
 		/// * `public_key`: A (serialized) public key associated with the DLEQ
-		///
 		#[pallet::weight(0)]
 		#[pallet::call_index(0)]
 		pub fn create(
@@ -206,7 +205,6 @@ pub mod pallet {
 		/// * `root`: The MMR root
 		/// * `size`: The size (number of leaves) of the MMR
 		/// * `proof`: A (serialized) DLEQ proof
-		///
 		#[pallet::weight(0)]
 		#[pallet::call_index(1)]
 		pub fn update(
@@ -252,7 +250,6 @@ pub mod pallet {
 		///   position
 		/// * `size`: The size of the Merkle proof
 		/// * `call`: The call to be proxied
-		///
 		#[pallet::weight(0)]
 		#[pallet::call_index(2)]
 		pub fn proxy(

--- a/pallets/murmur/src/tests.rs
+++ b/pallets/murmur/src/tests.rs
@@ -16,16 +16,19 @@
 
 use crate::{self as murmur, mock::*, Error};
 use codec::Encode;
-use frame_support::{assert_ok, assert_noop, traits::ConstU32, BoundedVec};
+use frame_support::{assert_noop, assert_ok, traits::ConstU32, BoundedVec};
 use frame_system::Call as SystemCall;
-use murmur_core::{murmur::EngineTinyBLS377, types::{BlockNumber, Identity, IdentityBuilder}};
-use murmur_test_utils::{MurmurStore, get_dummy_beacon_pubkey};
+use log::info;
+use murmur_core::{
+	murmur::EngineTinyBLS377,
+	types::{BlockNumber, Identity, IdentityBuilder},
+};
+use murmur_test_utils::{get_dummy_beacon_pubkey, MurmurStore};
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
 use sp_consensus_beefy_etf::{known_payloads, Commitment, Payload};
 use sp_core::{bls377, Pair};
 use w3f_bls::{DoublePublicKey, SerializableToBytes, TinyBLS377};
-use rand_chacha::ChaCha20Rng;
-use rand_core::SeedableRng;
-use log::info;
 
 #[derive(Debug)]
 pub struct BasicIdBuilder;
@@ -45,9 +48,8 @@ impl IdentityBuilder<BlockNumber> for BasicIdBuilder {
 /*
 Test Contants
 */
-pub const BLOCK_SCHEDULE: &[BlockNumber] = &[
-	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-];
+pub const BLOCK_SCHEDULE: &[BlockNumber] =
+	&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
 pub const WHEN: u64 = 10;
 pub const SEED: &[u8] = &[1, 2, 3];
 
@@ -72,7 +74,7 @@ fn it_can_create_new_proxy_with_unique_name() {
 
 	new_test_ext(vec![0]).execute_with(|| {
 		let round_pubkey_bytes = get_dummy_beacon_pubkey();
-				let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
+		let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
 
 		let mut rng = ChaCha20Rng::seed_from_u64(0);
 
@@ -82,7 +84,8 @@ fn it_can_create_new_proxy_with_unique_name() {
 			0,
 			round_pubkey,
 			&mut rng,
-		).unwrap();
+		)
+		.unwrap();
 
 		let root = mmr_store.root.clone();
 
@@ -119,14 +122,15 @@ fn it_fails_to_create_new_proxy_with_duplicate_name() {
 		let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
 
 		let mut rng = ChaCha20Rng::seed_from_u64(0);
-		
+
 		let mmr_store = MurmurStore::<EngineTinyBLS377>::new::<BasicIdBuilder, ChaCha20Rng>(
 			seed.clone().into(),
 			block_schedule.clone(),
 			0,
 			round_pubkey,
 			&mut rng,
-		).unwrap();
+		)
+		.unwrap();
 
 		let root = mmr_store.root.clone();
 		let bounded_root = BoundedVec::<u8, ConstU32<32>>::truncate_from(root.0);
@@ -146,15 +150,17 @@ fn it_fails_to_create_new_proxy_with_duplicate_name() {
 		let registered_proxy = murmur::Registry::<Test>::get(bounded_name.clone());
 		assert!(registered_proxy.is_some());
 
-
-		assert_noop!(Murmur::create(
-			RuntimeOrigin::signed(0),
-			bounded_name.clone(),
-			bounded_root,
-			size,
-			bounded_proof.clone(),
-			bounded_pubkey.clone(),
-		), Error::<Test>::DuplicateName);
+		assert_noop!(
+			Murmur::create(
+				RuntimeOrigin::signed(0),
+				bounded_name.clone(),
+				bounded_root,
+				size,
+				bounded_proof.clone(),
+				bounded_pubkey.clone(),
+			),
+			Error::<Test>::DuplicateName
+		);
 
 		// verify that the proxy exists
 	});
@@ -170,30 +176,34 @@ fn it_can_update_proxy() {
 		let round_pubkey_bytes = get_dummy_beacon_pubkey();
 
 		let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
-		let same_round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
+		let same_round_pubkey =
+			DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
 
 		let mut rng = ChaCha20Rng::seed_from_u64(0);
 
 		let mmr_store = MurmurStore::<EngineTinyBLS377>::new::<BasicIdBuilder, ChaCha20Rng>(
-            SEED.to_vec(),
-            BLOCK_SCHEDULE.to_vec(),
-            0,
-            round_pubkey,
-            &mut rng,
-        ).unwrap();
+			SEED.to_vec(),
+			BLOCK_SCHEDULE.to_vec(),
+			0,
+			round_pubkey,
+			&mut rng,
+		)
+		.unwrap();
 
 		let proof = mmr_store.proof.clone();
 		let pk = mmr_store.public_key.clone();
 
 		// use a new rng to ensure non-deterministic output
 		let mut new_rng = ChaCha20Rng::seed_from_u64(1);
-		let another_murmur_store = MurmurStore::<EngineTinyBLS377>::new::<BasicIdBuilder, ChaCha20Rng>(
-            SEED.to_vec(),
-            BLOCK_SCHEDULE.to_vec(),
-            1,
-            same_round_pubkey,
-            &mut new_rng,
-        ).unwrap();
+		let another_murmur_store =
+			MurmurStore::<EngineTinyBLS377>::new::<BasicIdBuilder, ChaCha20Rng>(
+				SEED.to_vec(),
+				BLOCK_SCHEDULE.to_vec(),
+				1,
+				same_round_pubkey,
+				&mut new_rng,
+			)
+			.unwrap();
 
 		let another_proof = another_murmur_store.proof;
 
@@ -217,12 +227,12 @@ fn it_can_update_proxy() {
 		let registered_proxy = murmur::Registry::<Test>::get(bounded_name.clone());
 		assert!(registered_proxy.is_some());
 
-
 		/* UPDATE THE PROXY */
 		let second_root = another_murmur_store.root.clone();
 		let second_bounded_root = BoundedVec::<u8, ConstU32<32>>::truncate_from(second_root.0);
-		let second_bounded_proof = BoundedVec::<u8, ConstU32<80>>::truncate_from(another_proof.clone());
-		
+		let second_bounded_proof =
+			BoundedVec::<u8, ConstU32<80>>::truncate_from(another_proof.clone());
+
 		assert_ok!(Murmur::update(
 			RuntimeOrigin::signed(0),
 			bounded_name.clone(),
@@ -244,20 +254,22 @@ fn it_can_proxy_valid_calls() {
 		let round_pubkey = DoublePublicKey::<TinyBLS377>::from_bytes(&round_pubkey_bytes).unwrap();
 
 		let mut rng = ChaCha20Rng::seed_from_u64(0);
-		
+
 		let mmr_store = MurmurStore::<EngineTinyBLS377>::new::<BasicIdBuilder, ChaCha20Rng>(
 			SEED.to_vec(),
 			BLOCK_SCHEDULE.to_vec().clone(),
 			0,
 			round_pubkey,
 			&mut rng,
-		).unwrap();
+		)
+		.unwrap();
 
 		let root = mmr_store.root.clone();
 		let bounded_root = BoundedVec::<u8, ConstU32<32>>::truncate_from(root.0);
-		let bounded_pubkey = BoundedVec::<u8, ConstU32<48>>::truncate_from(mmr_store.public_key.clone());
+		let bounded_pubkey =
+			BoundedVec::<u8, ConstU32<48>>::truncate_from(mmr_store.public_key.clone());
 		let bounded_proof = BoundedVec::<u8, ConstU32<80>>::truncate_from(mmr_store.proof.clone());
-	
+
 		assert_ok!(Murmur::create(
 			RuntimeOrigin::signed(0),
 			bounded_name.clone(),
@@ -271,15 +283,14 @@ fn it_can_proxy_valid_calls() {
 		// in practice, the rng would be seeded from user input
 		// along with some secure source of entropy
 		let call = call_remark(vec![1, 2, 3, 4, 5]);
-		let (merkle_proof, commitment, ciphertext, pos) = mmr_store
-			.execute(
-				SEED.to_vec().clone(), 
-				10,
-				call.encode().to_vec(),
-			).unwrap();
+		let (merkle_proof, commitment, ciphertext, pos) =
+			mmr_store.execute(SEED.to_vec().clone(), 10, call.encode().to_vec()).unwrap();
 
-		let proof_items: Vec<Vec<u8>> =
-			merkle_proof.proof_items().iter().map(|leaf| leaf.0.to_vec()).collect::<Vec<_>>();
+		let proof_items: Vec<Vec<u8>> = merkle_proof
+			.proof_items()
+			.iter()
+			.map(|leaf| leaf.0.to_vec())
+			.collect::<Vec<_>>();
 
 		assert_ok!(Murmur::proxy(
 			RuntimeOrigin::signed(0),

--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -507,9 +507,9 @@ pub mod pallet {
 			let call_hash = T::CallHasher::hash_of(&call);
 			let now = system::Pallet::<T>::block_number();
 			Self::edit_announcements(&delegate.clone(), |ann| {
-				ann.real != real
-					|| ann.call_hash != call_hash
-					|| now.saturating_sub(ann.height) < def.delay
+				ann.real != real ||
+					ann.call_hash != call_hash ||
+					now.saturating_sub(ann.height) < def.delay
 			})
 			.map_err(|_| Error::<T>::Unannounced)?;
 
@@ -769,8 +769,8 @@ impl<T: Config> Pallet<T> {
 		force_proxy_type: Option<T::ProxyType>,
 	) -> Result<ProxyDefinition<T::AccountId, T::ProxyType, BlockNumberFor<T>>, DispatchError> {
 		let f = |x: &ProxyDefinition<T::AccountId, T::ProxyType, BlockNumberFor<T>>| -> bool {
-			x.delegate.clone() == delegate
-				&& force_proxy_type.as_ref().map_or(true, |y| &x.proxy_type == y)
+			x.delegate.clone() == delegate &&
+				force_proxy_type.as_ref().map_or(true, |y| &x.proxy_type == y)
 		};
 		Ok(Proxies::<T>::get(real).0.into_iter().find(f).ok_or(Error::<T>::NotProxy)?)
 	}
@@ -788,19 +788,15 @@ impl<T: Config> Pallet<T> {
 			match c.is_sub_type() {
 				// Proxy call cannot add or remove a proxy with more permissions than it already
 				// has.
-				Some(Call::add_proxy { ref proxy_type, .. })
-				| Some(Call::remove_proxy { ref proxy_type, .. })
+				Some(Call::add_proxy { ref proxy_type, .. }) |
+				Some(Call::remove_proxy { ref proxy_type, .. })
 					if !def.proxy_type.is_superset(proxy_type) =>
-				{
-					false
-				},
+					false,
 				// Proxy call cannot remove all proxies or kill pure proxies unless it has full
 				// permissions.
 				Some(Call::remove_proxies { .. }) | Some(Call::kill_pure { .. })
 					if def.proxy_type != T::ProxyType::default() =>
-				{
-					false
-				},
+					false,
 				_ => def.proxy_type.filter(c),
 			}
 		});

--- a/pallets/scheduler/src/lib.rs
+++ b/pallets/scheduler/src/lib.rs
@@ -1013,9 +1013,8 @@ impl<T: Config> Pallet<T> {
 		let dispatch_origin = origin.into();
 		let (maybe_actual_call_weight, result) = match call.dispatch(dispatch_origin) {
 			Ok(post_info) => (post_info.actual_weight, Ok(())),
-			Err(error_and_info) => {
-				(error_and_info.post_info.actual_weight, Err(error_and_info.error))
-			},
+			Err(error_and_info) =>
+				(error_and_info.post_info.actual_weight, Err(error_and_info.error)),
 		};
 		let call_weight = maybe_actual_call_weight.unwrap_or(call_weight);
 		let _ = weight.try_consume(base_weight);

--- a/pallets/scheduler/src/tests.rs
+++ b/pallets/scheduler/src/tests.rs
@@ -674,12 +674,11 @@ fn on_initialize_weight_is_correct() {
 		// Will include the named periodic only
 		assert_eq!(
 			Scheduler::on_initialize(1),
-			TestWeightInfo::service_agendas_base()
-				+ TestWeightInfo::service_agenda_base(1)
-				+ <TestWeightInfo as MarginalWeightInfo>::service_task(None, true, true)
-				+ TestWeightInfo::execute_dispatch_unsigned()
-				+ call_weight
-				+ Weight::from_parts(4, 0)
+			TestWeightInfo::service_agendas_base() +
+				TestWeightInfo::service_agenda_base(1) +
+				<TestWeightInfo as MarginalWeightInfo>::service_task(None, true, true) +
+				TestWeightInfo::execute_dispatch_unsigned() +
+				call_weight + Weight::from_parts(4, 0)
 		);
 		assert_eq!(IncompleteSince::<Test>::get(), None);
 		assert_eq!(logger::log(), vec![(root(), 2600u32)]);
@@ -687,16 +686,14 @@ fn on_initialize_weight_is_correct() {
 		// Will include anon and anon periodic
 		assert_eq!(
 			Scheduler::on_initialize(2),
-			TestWeightInfo::service_agendas_base()
-				+ TestWeightInfo::service_agenda_base(2)
-				+ <TestWeightInfo as MarginalWeightInfo>::service_task(None, false, true)
-				+ TestWeightInfo::execute_dispatch_unsigned()
-				+ call_weight
-				+ Weight::from_parts(3, 0)
-				+ <TestWeightInfo as MarginalWeightInfo>::service_task(None, false, false)
-				+ TestWeightInfo::execute_dispatch_unsigned()
-				+ call_weight
-				+ Weight::from_parts(2, 0)
+			TestWeightInfo::service_agendas_base() +
+				TestWeightInfo::service_agenda_base(2) +
+				<TestWeightInfo as MarginalWeightInfo>::service_task(None, false, true) +
+				TestWeightInfo::execute_dispatch_unsigned() +
+				call_weight + Weight::from_parts(3, 0) +
+				<TestWeightInfo as MarginalWeightInfo>::service_task(None, false, false) +
+				TestWeightInfo::execute_dispatch_unsigned() +
+				call_weight + Weight::from_parts(2, 0)
 		);
 		assert_eq!(IncompleteSince::<Test>::get(), None);
 		assert_eq!(logger::log(), vec![(root(), 2600u32), (root(), 69u32), (root(), 42u32)]);
@@ -704,12 +701,11 @@ fn on_initialize_weight_is_correct() {
 		// Will include named only
 		assert_eq!(
 			Scheduler::on_initialize(3),
-			TestWeightInfo::service_agendas_base()
-				+ TestWeightInfo::service_agenda_base(1)
-				+ <TestWeightInfo as MarginalWeightInfo>::service_task(None, true, false)
-				+ TestWeightInfo::execute_dispatch_unsigned()
-				+ call_weight
-				+ Weight::from_parts(1, 0)
+			TestWeightInfo::service_agendas_base() +
+				TestWeightInfo::service_agenda_base(1) +
+				<TestWeightInfo as MarginalWeightInfo>::service_task(None, true, false) +
+				TestWeightInfo::execute_dispatch_unsigned() +
+				call_weight + Weight::from_parts(1, 0)
 		);
 		assert_eq!(IncompleteSince::<Test>::get(), None);
 		assert_eq!(

--- a/primitives/consensus/beefy-etf/src/lib.rs
+++ b/primitives/consensus/beefy-etf/src/lib.rs
@@ -390,10 +390,10 @@ where
 	//   have different validator set ids,
 	//   or both votes have the same commitment,
 	//     --> the equivocation is invalid.
-	if first.id != second.id
-		|| first.commitment.block_number != second.commitment.block_number
-		|| first.commitment.validator_set_id != second.commitment.validator_set_id
-		|| first.commitment.payload == second.commitment.payload
+	if first.id != second.id ||
+		first.commitment.block_number != second.commitment.block_number ||
+		first.commitment.validator_set_id != second.commitment.validator_set_id ||
+		first.commitment.payload == second.commitment.payload
 	{
 		return false;
 	}

--- a/primitives/consensus/beefy-etf/src/test_utils.rs
+++ b/primitives/consensus/beefy-etf/src/test_utils.rs
@@ -168,7 +168,8 @@ pub fn generate_equivocation_proof(
 }
 
 /// Helper function to prepare initial secrets and resharing for ETF conensus
-/// return a vec of (authority id, resharing, pubkey commitment) along with ibe public key against the master secret
+/// return a vec of (authority id, resharing, pubkey commitment) along with ibe public key against
+/// the master secret
 pub fn etf_genesis<E: EngineBLS>(
 	initial_authorities: Vec<BeefyId>,
 ) -> (Vec<u8>, Vec<(BeefyId, Vec<u8>)>) {

--- a/primitives/consensus/beefy-etf/src/test_utils.rs
+++ b/primitives/consensus/beefy-etf/src/test_utils.rs
@@ -18,10 +18,10 @@
 // #[cfg(feature = "bls-experimental")]
 // use crate::bls_bls_crypto;
 use crate::{
-	bls_crypto, AuthorityIdBound, BeefySignatureHasher, Commitment, EquivocationProof, Payload,
-	ValidatorSetId, VoteMessage, bls_crypto::{AuthorityId as BeefyId},
+	bls_crypto, bls_crypto::AuthorityId as BeefyId, AuthorityIdBound, BeefySignatureHasher,
+	Commitment, EquivocationProof, Payload, ValidatorSetId, VoteMessage,
 };
-use sp_application_crypto::{AppCrypto, AppPair, RuntimeAppPublic, Wraps, UncheckedFrom};
+use sp_application_crypto::{AppCrypto, AppPair, RuntimeAppPublic, UncheckedFrom, Wraps};
 use sp_core::{bls377, Pair};
 use sp_runtime::traits::Hash;
 
@@ -31,10 +31,7 @@ use strum::IntoEnumIterator;
 
 use ark_serialize::CanonicalSerialize;
 use ark_std::UniformRand;
-use etf_crypto_primitives::{
-	proofs::hashed_el_gamal_sigma::BatchPoK,
-	dpss::acss::DoubleSecret
-};
+use etf_crypto_primitives::{dpss::acss::DoubleSecret, proofs::hashed_el_gamal_sigma::BatchPoK};
 use rand::rngs::OsRng;
 use w3f_bls::{DoublePublicKey, DoublePublicKeyScheme, EngineBLS, SerializableToBytes, TinyBLS377};
 


### PR DESCRIPTION
This PR makes the `random_at` function to return an Option<[u8;32]> instead of a [u8;32], so that when the random value is not found the fn returns None instead of [0;32]

Additionally, this PR enforces the code to be formatted with +nightly

Note to the reviewers: the only code added is in `pallets/drand` and `.pre-commit-config.yaml`, the rest is just code formatting