### PR TITLE
Host arkworks feat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,60 +2164,6 @@ dependencies = [
 [[package]]
 name = "etf-crypto-primitives"
 version = "0.2.4"
-source = "git+https://github.com/ideal-lab5/etf-sdk.git?branch=tony/dev#159ed603ca8a31b7d2e5f4437c62411c4d1fd743"
-dependencies = [
- "aes-gcm",
- "ark-bls12-377",
- "ark-bls12-381",
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "array-bytes 6.2.3",
- "chacha20poly1305",
- "generic-array 0.14.7",
- "parity-scale-codec",
- "rand_chacha 0.3.1",
- "scale-info",
- "serde",
- "serde_cbor",
- "serde_json",
- "sha2 0.10.8",
- "sha3",
- "w3f-bls 0.1.4",
-]
-
-[[package]]
-name = "etf-crypto-primitives"
-version = "0.2.4"
-source = "git+https://github.com/ideal-lab5/etf-sdk.git?branch=tony/dev#159ed603ca8a31b7d2e5f4437c62411c4d1fd743"
-dependencies = [
- "aes-gcm",
- "ark-bls12-377",
- "ark-bls12-381",
- "ark-ec",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
- "array-bytes 6.2.3",
- "chacha20poly1305",
- "generic-array 0.14.7",
- "parity-scale-codec",
- "rand_chacha 0.3.1",
- "scale-info",
- "serde",
- "serde_cbor",
- "serde_json",
- "sha2 0.10.8",
- "sha3",
- "w3f-bls 0.1.4",
-]
-
-[[package]]
-name = "etf-crypto-primitives"
-version = "0.2.4"
 source = "git+http://github.com/ideal-lab5/etf-sdk?branch=w3fbls-migration#c6e61a89b94b57bcbde2293208a2875469f4fc5c"
 dependencies = [
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,33 @@ dependencies = [
 [[package]]
 name = "etf-crypto-primitives"
 version = "0.2.4"
+source = "git+https://github.com/ideal-lab5/etf-sdk.git?branch=tony/dev#159ed603ca8a31b7d2e5f4437c62411c4d1fd743"
+dependencies = [
+ "aes-gcm",
+ "ark-bls12-377",
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "array-bytes 6.2.3",
+ "chacha20poly1305",
+ "generic-array 0.14.7",
+ "parity-scale-codec",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "sha3",
+ "w3f-bls 0.1.4",
+]
+
+[[package]]
+name = "etf-crypto-primitives"
+version = "0.2.4"
 source = "git+http://github.com/ideal-lab5/etf-sdk?branch=w3fbls-migration#c6e61a89b94b57bcbde2293208a2875469f4fc5c"
 dependencies = [
  "aes-gcm",

--- a/pallets/drand/Cargo.toml
+++ b/pallets/drand/Cargo.toml
@@ -36,7 +36,7 @@ sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "re
 sp-io = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-crates-io-v1.14.0",  default-features = false}
 sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-crates-io-v1.14.0",  default-features = false}
 # arkworks dependencies
-sp-ark-bls12-381 = { git = "https://github.com/paritytech/substrate-curves", default-features = false }
+sp-ark-bls12-381 = { git = "https://github.com/paritytech/substrate-curves", default-features = false, optional = true }
 ark-bls12-381 = { version = "0.4.0", features = ["curve"], default-features = false }
 ark-serialize = { version = "0.4.0", features = [ "derive" ], default-features = false }
 ark-ff = { version = "0.4.0", default-features = false }
@@ -91,3 +91,4 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+host-arkworks = ["sp-ark-bls12-381"]

--- a/pallets/drand/README.md
+++ b/pallets/drand/README.md
@@ -11,7 +11,6 @@ Use this pallet in a Substrate runtime to acquire verifiable randomness from dra
 ### Node Requirements
 
 Usage of this pallet requires that the node support:
-- arkworks host functions
 - offchain workers
 - (optional - in case of smart contracts) Contracts pallet and drand  chain extension enabled 
 

--- a/pallets/drand/docs/how_it_works.md
+++ b/pallets/drand/docs/how_it_works.md
@@ -4,21 +4,16 @@ This document describes how the drand bridge pallet works.
 
 ## Overview
 
-Drand's quicknet periodically outputs pulses of verifiable randomness every 3 seconds. There are various API's which provide access to the beacon, with this pallet simply using the main `api.drand.sh` URI. This pallet runs an offchain worker, which executes each time a node imports a new (*not* finalized) block. 
+Drand's quicknet periodically outputs pulses of verifiable randomness every 3 seconds. There are various API's which provide access to the beacon, you can find the full list [here](https://drand.love/docs/http-api-reference), we've found that the best performing endpoint for us is `https://drand.cloudflare.com/`. This pallet runs an offchain worker, which executes each time a node imports a new (*not* finalized) block. 
 
-### Assumption and Limitations
+### Assumptions and Limitations
 
-1. Verifiying pulses is only possible for solochains. As the verification function requires the arkworks host functions to be added to the node service, which is not currently the case for the Polkadot node.
-The `pallet_drand::QuicknetVerifier::verify` function, used to verify the drand randomness, depends on arkworks and is far more performant when run natively than in wasm. Without this native support, the validators would take too long to run this verification in the PVF and likely discard the blocks that contain drand pulses.
-
-2. Drand config isn't verified before storing it, any value with a valid format will be stored.
-
-3. Because of the two previous limitations (the first one only affecting parachains), the pallet is not secure.
+1. Drand config isn't verified before storing it, any value with a valid format will be stored.
 *After closing https://github.com/ideal-lab5/idn-sdk/issues/3, this limitation will be removed. Though it will required to trust at least one OCW*
 
-3. Currently OCWs are at the will of the client’s “major sync oracle”, which means OCWs will not execute if the node is undergoing a “major sync” event. [ref]
+2. Currently OCWs are at the will of the client’s “major sync oracle”, which means OCWs will not execute if the node is undergoing a “major sync” event. [ref]
 
-4. It only supports drand’s quicknet, and so there is some trust placed in drand that they will retain liveness and that the league of entropy is not compromised. 
+3. It only supports Drand’s Quicknet, and so there is some trust placed in Drand that they will retain liveness and that the League of Entropy is not compromised. 
 
 ## Reading Pulses
 
@@ -35,7 +30,7 @@ Pulses are stored in a storage map.
 
 > Drand's Quicknet functions as a distributed, MPC protocol that produces and gossips threshold BLS signatures. In this flavor of drand, short signatures are used where the signature is in the $\mathbb{G}_1$ group and public keys are in $\mathbb{G}_2$. 
 
-The default implementation of the `Verifier` trait is `pallet_drand::QuicknetVerifier::verify`. In this function, to verify pulses from drand, we check the equality of the pairings: $e(-sig, g2) == e(m, pk)$  where $m = H(message = Sha256(round))$, $sig$ is the round signature, $g_2$ is a generator of the $\mathbb{G}_2$ group, and $pk$ in the public key associated with the beacon.
+The default implementation of the `Verifier` trait is `pallet_drand::verifier::QuicknetVerifier::verify`. In this function, to verify pulses from drand, we check the equality of the pairings: $e(-sig, g2) == e(m, pk)$  where $m = H(message = Sha256(round))$, $sig$ is the round signature, $g_2$ is a generator of the $\mathbb{G}_2$ group, and $pk$ in the public key associated with the beacon.
 
 <!-- TODO: improve this https://github.com/ideal-lab5/idn-sdk/issues/11 -->
-**NOTE: this verification is only avaliable onchain for solochains (see [Assumptions and Limitations](#assumption-and-limitations)). Offchain verification can be done using the [drand libs](https://github.com/drand)**
+**Offchain verification can be done using the [drand libs](https://github.com/drand)**

--- a/pallets/drand/docs/integration.md
+++ b/pallets/drand/docs/integration.md
@@ -2,22 +2,36 @@
 
 This guide details how to integrate the drand bridge pallet into the runtime.
 
-## Configure the Node Service 
+## Configure the Node Service
 
-### Add Arkworks Host Functions
+### Enable HTTP requests
 
-**NOTE: this step is only for solochains (see [Assumptions and Limitations](./integration.md#assumption-and-limitations))**
+Make sure the `enable_http_requests` is set to `true` in the `sc_offchain::OffchainWorkerOptions`.
 
-First you will need to add support for the arkworks host functions. Arkworks is far more performant when run natively than in wasm, so we achieve a massive boost in speed when using host functions.
+### Add Arkworks Host Functions (recommnded for solochains only)
+
+Arkworks is far more performant when run natively than in wasm, so we achieve a massive boost in speed when using host functions.
+For optimal performance, the drand bridge pallet can utilize arkworks cryptographic functions that run directly on the host machine rather than in wasm. Here's what you need to know:
+- For a Parachain:
+  - The arkworks host functions must be available on all collator and validator machines
+  - Since this availability cannot be guaranteed, and the relay chain may not support these functions, **it's recommended to run arkworks in wasm mode for parachains**
+  - This ensures consistent behavior across the network
+
+- For a Solochain:
+  - You have more control over the environment and can enable the arkworks host functions
+  - This will provide **significantly better performance** when verifiying drand pulses
+
+
+#### Add support for the arkworks host functions. 
 
 Near the top of `node/src/service.rs`, add change the `FullClient` to use the code below:
 
-``` rust
+```rust
 /// Host runctions required for Substrate and Arkworks
 #[cfg(not(feature = "runtime-benchmarks"))]
 pub type HostFunctions =
 	(
-		sp_io::SubstrateHostFunctions, 
+		sp_io::SubstrateHostFunctions,
 		sp_crypto_ec_utils::bls12_381::host_calls::HostFunctions
 	);
 
@@ -41,7 +55,7 @@ pub(crate) type FullClient = sc_service::TFullClient<
 
 Once completed. you must also update the wasm_executor instantiated when calling `new_partial` (or equivalent if you use something else). Ensure that the wasm executor uses the expected set of `HostFunctions` and the type passed to `new_full_parts` expects the correct wasm executor.
 
-``` rust
+```rust
 let executor = sc_service::new_wasm_executor::<HostFunctions>(config);
 let (client, backend, keystore_container, task_manager) =
     sc_service::new_full_parts::<Block, RuntimeApi, RuntimeExecutor>(
@@ -50,47 +64,34 @@ let (client, backend, keystore_container, task_manager) =
         executor,
     )?;
 ```
-### Enable HTTP requests
 
-Make sure the `enable_http_requests` is set to `true` in the `sc_offchain::OffchainWorkerOptions`.
+#### Enable the `host-arkwork` feature
 
-### Add Authority Keys 
+In your `Cargo.toml`, add the `host-arkworks` feature to the `pallet-drand` dependency.
 
-To add initial keys for an authority's OCW (e.g. Alice) you can do one of these:
-
-#### a. Programatically - ONLY FOR DEV ENVS
-
-Add this code inside of the if statement:
-``` rust
-if config.offchain_worker.enabled {
-    sp_keystore::Keystore::sr25519_generate_new(
-        &*keystore_container.keystore(),
-        node_template_runtime::pallet_drand::KEY_TYPE,
-        Some("//Alice"),
-    ).expect("Creating key with account Alice should succeed.");
-}
+```toml
+pallet-drand = { ... features = ["host-arkworks"]}
 ```
-
-#### b. Via Polkadot.js Apps
-
-1. Access the Polkadot.js Apps on your browser and connecto to your node.
-2. Navigate to "Developer > RPC Calls" and select the `author_insertKey` call.
-3. Fill in the parameters
-	- **Key type**: `drnd`
-	- **SURI**: The secret URI, usually a mnemonic seed phrase (for Alice it is `//Alice`)
-	- **Public key**: The public key derived from the SURI (for Alice it is `0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d`)
 
 ## Configure the Runtime
 
 To use this pallet, add it to a substrate runtime with
-``` rust
+
+```rust
+parameter_types! {
+	pub const UnsignedPriority: u64 = 1 << 20;
+	pub const ApiEndpoint: &'static str = "https://drand.cloudflare.com"; // See full list of endpoints at https://drand.love/docs/http-api-reference
+	pub const HttpFetchTimeout: u64 = 1_000;
+}
+
 impl pallet_drand::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_drand::weights::SubstrateWeight<Runtime>;
 	type AuthorityId = pallet_drand::crypto::TestAuthId;
-	type Verifier = pallet_drand::QuicknetVerifier; // Only for solochains, otherwise use `pallet_drand::UnsafeSkipVerifier`
-	type UnsignedPriority = ConstU64<{ 1 << 20 }>;
-	type HttpFetchTimeout = ConstU64<1_000>;
+	type UnsignedPriority = UnsignedPriority;
+	type HttpFetchTimeout = HttpFetchTimeout;
+	type Verifier = pallet_drand::verifier::QuicknetVerifier;
+	type ApiEndpoint = ApiEndpoint;
 }
 
 #[frame_support::runtime]
@@ -103,7 +104,8 @@ mod runtime {
 ```
 
 You will also need to configure the runtime to allow offchain workers to submit unsigned transactions. This can be done with:
-``` rust
+
+```rust
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
 where
 	RuntimeCall: From<LocalCall>,
@@ -158,7 +160,7 @@ RuntimeCall: From<C>,
 
 ## Smart Contracts Config
 
-This assumes that you have already integrated the contracts pallet in your  time. To use the drand pallet's randomness within smart contracts, we first add a chain extension to the runtime and then tell the contracts pallet to use it.
+This assumes that you have already integrated the contracts pallet in your time. To use the drand pallet's randomness within smart contracts, we first add a chain extension to the runtime and then tell the contracts pallet to use it.
 
 ### Add chain extension
 
@@ -166,12 +168,12 @@ This is just one possible way to write a chain extension. This can be customized
 
 At the bottom of `runtime/src/lib.rs`, add:
 
-``` rust
+```rust
 #[derive(Default)]
 pub struct DrandExtension;
 
 impl ChainExtension<Runtime> for DrandExtension {
-	
+
     fn call<E: Ext>(
         &mut self,
         env: Environment<E, InitState>,
@@ -186,14 +188,14 @@ impl ChainExtension<Runtime> for DrandExtension {
 			"[ChainExtension]|call|func_id:{:}",
 			func_id
 		);
-        match func_id {	
+        match func_id {
             1101 => {
                 let mut env = env.buf_in_buf_out();
 				let rand = Drand::latest_random();
 				env.write(&rand.encode(), false, None).map_err(|_| {
 					DispatchError::Other("Failed to write output randomness")
 				})?;
-				
+
 				Ok(RetVal::Converging(0))
             },
             _ => {
@@ -211,7 +213,7 @@ impl ChainExtension<Runtime> for DrandExtension {
 
 ### Configure Contracts Pallet
 
-``` rust
+```rust
 impl pallet_contracts::Config for Runtime {
 	...
 	type Randomness = Drand;
@@ -220,3 +222,32 @@ impl pallet_contracts::Config for Runtime {
 	...
 }
 ```
+
+## Add Authority Keys
+
+Because of the limitations defined in [Assumptions and Limitations](./how_it_works.md#assumption-and-limitations), you must add the initial keys for the authorities' OCWs once your chain is running.
+To add initial keys for an authority's OCW (e.g. Alice) you can do one of these:
+
+### a. Via command line
+
+```bash
+# Parameters
+NODE_URL="http://127.0.0.1:1234" # change this to your node's URL
+KEY_TYPE="drnd"
+SEED="//Alice" # change this to your authority's seed
+PUBLIC_KEY="0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d" # change this to your authority's public key
+
+# Insert the key
+curl -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","method":"author_insertKey","params":["'"$KEY_TYPE"'","'"$SEED"'","'"$PUBLIC_KEY"'"],"id":1}' \
+     $NODE_URL
+```
+
+### b. Via Polkadot.js Apps
+
+1. Access the Polkadot.js Apps on your browser and connecto to your node.
+2. Navigate to "Developer > RPC Calls" and select the `author_insertKey` call.
+3. Fill in the parameters
+   - **Key type**: `drnd`
+   - **SURI**: The secret URI, usually a mnemonic seed phrase (for Alice it is `//Alice`)
+   - **Public key**: The public key derived from the SURI (for Alice it is `0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d`)

--- a/pallets/drand/src/bls12_381.rs
+++ b/pallets/drand/src/bls12_381.rs
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+#[cfg(not(feature = "host-arkworks"))]
+use ark_bls12_381::{Bls12_381 as Bls12_381Opt, G1Affine as G1AffineOpt, G2Affine as G2AffineOpt};
 use ark_ec::pairing::Pairing;
 use ark_std::{ops::Neg, Zero};
+#[cfg(feature = "host-arkworks")]
 use sp_ark_bls12_381::{
 	Bls12_381 as Bls12_381Opt, G1Affine as G1AffineOpt, G2Affine as G2AffineOpt,
 };

--- a/pallets/drand/src/lib.rs
+++ b/pallets/drand/src/lib.rs
@@ -66,8 +66,6 @@ pub mod verifier;
 use types::*;
 use verifier::Verifier;
 
-const USAGE: ark_scale::Usage = ark_scale::WIRE;
-pub type ArkScale<T> = ark_scale::ArkScale<T, USAGE>;
 pub type RandomValue = [u8; 32];
 
 #[cfg(test)]

--- a/pallets/drand/src/mock.rs
+++ b/pallets/drand/src/mock.rs
@@ -83,6 +83,7 @@ where
 parameter_types! {
 	pub const UnsignedPriority: u64 = 1 << 20;
 	pub const ApiEndpoint: &'static str = "http://api";
+	pub const HttpFetchTimeout: u64 = 1_000;
 }
 
 impl pallet_drand_bridge::Config for Test {
@@ -91,7 +92,7 @@ impl pallet_drand_bridge::Config for Test {
 	type WeightInfo = pallet_drand_bridge::weights::SubstrateWeight<Test>;
 	type Verifier = QuicknetVerifier;
 	type UnsignedPriority = UnsignedPriority;
-	type HttpFetchTimeout = ConstU64<1_000>;
+	type HttpFetchTimeout = HttpFetchTimeout;
 	type ApiEndpoint = ApiEndpoint;
 }
 

--- a/pallets/drand/src/tests.rs
+++ b/pallets/drand/src/tests.rs
@@ -276,15 +276,6 @@ fn test_not_validate_unsigned_write_pulse_with_no_payload_signature() {
 
 #[test]
 #[ignore]
-fn test_validate_unsigned_write_pulse_by_non_authority() {
-	// TODO: https://github.com/ideal-lab5/idn-sdk/issues/3
-	todo!(
-		"the transaction should be validated even if the signer of the payload is not an authority"
-	);
-}
-
-#[test]
-#[ignore]
 fn test_not_validate_unsigned_set_beacon_config_by_non_autority() {
 	// TODO: https://github.com/ideal-lab5/idn-sdk/issues/3
 	todo!(

--- a/pallets/drand/src/verifier.rs
+++ b/pallets/drand/src/verifier.rs
@@ -22,13 +22,23 @@ use crate::{
 use alloc::{format, string::String, vec::Vec};
 use ark_ec::{hashing::HashToCurve, AffineRepr};
 use ark_serialize::CanonicalSerialize;
-use codec::Decode;
 use sha2::{Digest, Sha256};
-use sp_ark_bls12_381::{G1Affine as G1AffineOpt, G2Affine as G2AffineOpt};
 use timelock::{curves::drand::TinyBLS381, tlock::EngineBLS};
 
+#[cfg(not(feature = "host-arkworks"))]
+use ark_bls12_381::{G1Affine as G1AffineOpt, G2Affine as G2AffineOpt};
+#[cfg(not(feature = "host-arkworks"))]
+use ark_serialize::CanonicalDeserialize;
+
+#[cfg(feature = "host-arkworks")]
+use codec::Decode;
+#[cfg(feature = "host-arkworks")]
+use sp_ark_bls12_381::{G1Affine as G1AffineOpt, G2Affine as G2AffineOpt};
+
+#[cfg(feature = "host-arkworks")]
 const USAGE: ark_scale::Usage = ark_scale::WIRE;
-pub type ArkScale<T> = ark_scale::ArkScale<T, USAGE>;
+#[cfg(feature = "host-arkworks")]
+type ArkScale<T> = ark_scale::ArkScale<T, USAGE>;
 
 /// Constructs a message (e.g. signed by drand)
 fn message(current_round: RoundNumber, prev_sig: &[u8]) -> Vec<u8> {
@@ -59,16 +69,34 @@ pub trait Verifier {
 pub struct QuicknetVerifier;
 
 impl Verifier for QuicknetVerifier {
+	/// Verify the given pulse using beacon_config
+	/// Returns true if the pulse is valid, false otherwise.
+	///
+	/// If `host-arkworks` feature is enabled, it will look for the arkworks functions in the host,
+	/// if they are not found it will cause a panic.
+	/// Running the arkworks functions in the host is significantly faster than running them inside
+	/// wasm, but this is not always possible if we don't control the validator nodes (i.e. when
+	/// running a parachain).
+	///
+	/// See see docs/integration.md for more information on how to use the `host-arkworks` feature.
 	fn verify(beacon_config: BeaconConfiguration, pulse: Pulse) -> Result<bool, String> {
 		// decode public key (pk)
-		let pk =
-			ArkScale::<G2AffineOpt>::decode(&mut beacon_config.public_key.into_inner().as_slice())
-				.map_err(|e| format!("Failed to decode public key: {}", e))?;
+		#[cfg(feature = "host-arkworks")]
+		let pk = ArkScale::<G2AffineOpt>::decode(&mut beacon_config.public_key.into_inner().as_slice())
+			.map_err(|e| format!("Failed to decode public key: {}", e))?;
+		#[cfg(not(feature = "host-arkworks"))]
+		let pk = G2AffineOpt::deserialize_compressed(
+			&mut beacon_config.public_key.into_inner().as_slice(),
+		)
+		.map_err(|e| format!("Failed to decode public key: {}", e))?;
 
 		// decode signature (sigma)
-		let signature =
-			ArkScale::<G1AffineOpt>::decode(&mut pulse.signature.into_inner().as_slice())
-				.map_err(|e| format!("Failed to decode signature: {}", e))?;
+		#[cfg(feature = "host-arkworks")]
+		let signature = ArkScale::<G1AffineOpt>::decode(&mut pulse.signature.into_inner().as_slice())
+			.map_err(|e| format!("Failed to decode signature: {}", e))?;
+		#[cfg(not(feature = "host-arkworks"))]
+		let signature = G1AffineOpt::deserialize_compressed(&mut pulse.signature.into_inner().as_slice())
+			.map_err(|e| format!("Failed to decode signature: {}", e))?;
 
 		// m = sha256({} || {round})
 		let message = message(pulse.round, &[]);
@@ -82,16 +110,28 @@ impl Verifier for QuicknetVerifier {
 			.serialize_compressed(&mut bytes)
 			.map_err(|e| format!("Failed to serialize message hash: {}", e))?;
 
+		#[cfg(feature = "host-arkworks")]
 		let message_on_curve = ArkScale::<G1AffineOpt>::decode(&mut &bytes[..])
+			.map_err(|e| format!("Failed to decode message on curve: {}", e))?;
+		#[cfg(not(feature = "host-arkworks"))]
+		let message_on_curve = G1AffineOpt::deserialize_compressed(&mut &bytes[..])
 			.map_err(|e| format!("Failed to decode message on curve: {}", e))?;
 
 		let g2 = G2AffineOpt::generator();
 
-		Ok(bls12_381::fast_pairing_opt(signature.0, g2, message_on_curve.0, pk.0))
+		#[cfg(feature = "host-arkworks")]
+		let result = bls12_381::fast_pairing_opt(signature.0, g2, message_on_curve.0, pk.0);
+		#[cfg(not(feature = "host-arkworks"))]
+		let result = bls12_381::fast_pairing_opt(signature, g2, message_on_curve, pk);
+
+		Ok(result)
 	}
 }
 
-/// The unsafe skip verifier is just a pass-through verification, always returns true
+/// The unsafe skip verifier is just a pass-through verification, always returns true.
+/// Skipping the verification process can be dangerous, as it allows for malicious actors to
+/// inject false pulses into the system. But it speeds up the process significantly.
+/// This is useful for testing purposes or when fully trusting the source of the pulses.
 pub struct UnsafeSkipVerifier;
 impl Verifier for UnsafeSkipVerifier {
 	fn verify(_beacon_config: BeaconConfiguration, _pulse: Pulse) -> Result<bool, String> {

--- a/pallets/drand/substrate-node-template/runtime/Cargo.toml
+++ b/pallets/drand/substrate-node-template/runtime/Cargo.toml
@@ -83,7 +83,7 @@ frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", b
 frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-crates-io-v1.14.0",  default-features = false, optional = true }
 
 # The pallet in this template.
-pallet-drand = { path = "../../", default-features = false }
+pallet-drand = { path = "../../", default-features = false, features = ["host-arkworks"]}
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/polkadot-sdk.git", branch = "release-crates-io-v1.14.0",  optional = true }

--- a/pallets/drand/substrate-node-template/runtime/src/lib.rs
+++ b/pallets/drand/substrate-node-template/runtime/src/lib.rs
@@ -289,14 +289,15 @@ impl pallet_sudo::Config for Runtime {
 parameter_types! {
 	pub const UnsignedPriority: u64 = 1 << 20;
 	pub const ApiEndpoint: &'static str = "https://drand.cloudflare.com";
+	pub const HttpFetchTimeout: u64 = 1_000;
 }
 
 impl pallet_drand::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = pallet_drand::weights::SubstrateWeight<Runtime>;
 	type AuthorityId = pallet_drand::crypto::TestAuthId;
-	type UnsignedPriority = ConstU64<{ 1 << 20 }>;
-	type HttpFetchTimeout = ConstU64<1_000>;
+	type UnsignedPriority = UnsignedPriority;
+	type HttpFetchTimeout = HttpFetchTimeout;
 	type Verifier = pallet_drand::verifier::QuicknetVerifier;
 	type ApiEndpoint = ApiEndpoint;
 }


### PR DESCRIPTION
This PR enables the QuicknetVerification even when the arkworks functions are not enabled on the host.

It adds the possibility to run these functions directly in the runtime's wasm by default, or let them run on the host when enabling the `host-arkworks` feature.

Adjust the documentation accordingly.