### PR TITLE
feat(108+113): create logic for fees collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,6 +3874,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 35.0.0",
+ "sp-arithmetic",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
  "sp-runtime 40.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,6 +3876,7 @@ dependencies = [
  "sp-api 35.0.0",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
+ "sp-runtime 40.1.0",
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "staging-xcm",
  "staging-xcm-builder",

--- a/pallets/idn-manager/Cargo.toml
+++ b/pallets/idn-manager/Cargo.toml
@@ -18,6 +18,7 @@ scale-info = { version = "2.11.6", default-features = false }
 sp-api = { version = "35.0.0",  default-features = false }
 sp-core = { version = "35.0.0",  default-features = false }
 sp-io = { version = "39.0.0",  default-features = false}
+sp-runtime = { version = "40.1.0",  default-features = false}
 sp-std = { version = "14.0.0",  default-features = false }
 xcm = { version = "15.0.1", default-features = false, package = "staging-xcm" }
 xcm-builder = { version = "18.0.0", default-features = false, package = "staging-xcm-builder" }

--- a/pallets/idn-manager/Cargo.toml
+++ b/pallets/idn-manager/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false }
 scale-info = { version = "2.11.6", default-features = false }
+sp-arithmetic = { version = "26.0.0", default-features = false }
 sp-api = { version = "35.0.0",  default-features = false }
 sp-core = { version = "35.0.0",  default-features = false }
 sp-io = { version = "39.0.0",  default-features = false}
@@ -40,6 +41,7 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"idn-traits/std",
+	"sp-arithmetic/std",
 	"sp-core/std",
 	"sp-io/std",
 	"sp-std/std",

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 by Ideal Labs, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # Implementations of public traits
+
+use crate::{
+	self as pallet_idn_manager, traits::FeesError, HoldReason, Subscription, SubscriptionTrait,
+};
+use codec::Encode;
+use frame_support::{
+	pallet_prelude::DispatchError,
+	traits::{
+		tokens::{fungible::hold::Mutate, Fortitude, Precision, Restriction},
+		Get,
+	},
+};
+use sp_runtime::{AccountId32, Saturating};
+use sp_std::marker::PhantomData;
+
+impl<AccountId, BlockNumber, Metadata> SubscriptionTrait<AccountId>
+	for Subscription<AccountId, BlockNumber, Metadata>
+{
+	fn subscriber(&self) -> &AccountId {
+		&self.details.subscriber
+	}
+}
+
+impl SubscriptionTrait<()> for () {
+	fn subscriber(&self) -> &() {
+		&()
+	}
+}
+
+/// A FeesManager implementation that holds a dynamic treasury account.
+pub struct FeesManagerImpl<Treasury, BaseFee, Sub, BlockNumber, Balances> {
+	pub _phantom: FeesManagerPhantom<Treasury, BaseFee, Sub, BlockNumber, Balances>,
+}
+type FeesManagerPhantom<Treasury, BaseFee, Sub, BlockNumber, Balances> = (
+	PhantomData<Treasury>,
+	PhantomData<BaseFee>,
+	PhantomData<Sub>,
+	PhantomData<BlockNumber>,
+	PhantomData<Balances>,
+);
+
+impl<
+		T: Get<AccountId32>,
+		B: Get<Balances::Balance>,
+		S: SubscriptionTrait<AccountId32>,
+		BlockNumber,
+		Balances: Mutate<AccountId32>,
+	> pallet_idn_manager::FeesManager<Balances::Balance, BlockNumber, S, DispatchError, AccountId32>
+	for FeesManagerImpl<T, B, S, BlockNumber, Balances>
+where
+	Balances::Balance: From<BlockNumber>,
+	Balances::Reason: From<HoldReason>,
+{
+	fn calculate_subscription_fees(amount: BlockNumber) -> Balances::Balance {
+		let base_fee = B::get();
+		base_fee.saturating_mul(amount.into())
+	}
+	fn calculate_refund_fees(
+		_init_amount: BlockNumber,
+		current_amount: BlockNumber,
+	) -> Balances::Balance {
+		// in this case of a liner function, the refund's is the same as the fees'
+		Self::calculate_subscription_fees(current_amount)
+	}
+	fn collect_fees(
+		fees: Balances::Balance,
+		sub: S,
+	) -> Result<Balances::Balance, FeesError<Balances::Balance, DispatchError>> {
+		// Collect the held fees from the subscriber
+		let collected = Balances::transfer_on_hold(
+			&HoldReason::Fees.into(),
+			sub.subscriber(),
+			&T::get(),
+			fees,
+			Precision::BestEffort,
+			Restriction::Free,
+			Fortitude::Polite,
+		)
+		.map_err(FeesError::Other)?;
+
+		// Ensure the correct amount was collected.
+		if collected < fees {
+			return Err(FeesError::NotEnoughBalance { needed: fees, balance: collected });
+		}
+
+		Ok(collected)
+	}
+}
+
+pub struct DepositCalculatorImpl;
+
+impl<S: SubscriptionTrait<AccountId32> + Encode> pallet_idn_manager::DepositCalculator<u64, S>
+	for DepositCalculatorImpl
+{
+	fn calculate_storage_deposit(sub: &S) -> u64 {
+		let storage_deposit_multiplier = 10;
+		// calculate the size of scale encoded `sub`
+		let encoded_size = sub.encode().len() as u64;
+		encoded_size.saturating_mul(storage_deposit_multiplier)
+	}
+}

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -105,15 +105,21 @@ where
 	}
 }
 
-pub struct DepositCalculatorImpl;
+pub struct DepositCalculatorImpl<SDMultiplier: Get<Balance>, Balance> {
+	pub _phantom: (PhantomData<SDMultiplier>, PhantomData<Balance>),
+}
 
-impl<S: SubscriptionTrait<AccountId32> + Encode> pallet_idn_manager::DepositCalculator<u64, S>
-	for DepositCalculatorImpl
+impl<
+		S: SubscriptionTrait<AccountId32> + Encode,
+		SDMultiplier: Get<Balance>,
+		Balance: From<u32> + Saturating,
+	> pallet_idn_manager::DepositCalculator<Balance, S>
+	for DepositCalculatorImpl<SDMultiplier, Balance>
 {
-	fn calculate_storage_deposit(sub: &S) -> u64 {
-		let storage_deposit_multiplier = 10;
+	fn calculate_storage_deposit(sub: &S) -> Balance {
+		let storage_deposit_multiplier = SDMultiplier::get();
 		// calculate the size of scale encoded `sub`
-		let encoded_size = sub.encode().len() as u64;
-		encoded_size.saturating_mul(storage_deposit_multiplier)
+		let encoded_size = sub.encode().len() as u32;
+		storage_deposit_multiplier.saturating_mul(encoded_size.into())
 	}
 }

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -76,7 +76,7 @@ where
 		_init_amount: BlockNumber,
 		current_amount: BlockNumber,
 	) -> Balances::Balance {
-		// in this case of a liner function, the refund's is the same as the fees'
+		// in this case of a linear function, the refund's is the same as the fees'
 		Self::calculate_subscription_fees(current_amount)
 	}
 	fn collect_fees(
@@ -96,6 +96,7 @@ where
 		.map_err(FeesError::Other)?;
 
 		// Ensure the correct amount was collected.
+		// TODO: error to bubble up and be handled by caller https://github.com/ideal-lab5/idn-sdk/issues/107
 		if collected < fees {
 			return Err(FeesError::NotEnoughBalance { needed: fees, balance: collected });
 		}

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -27,10 +27,11 @@ use frame_support::{
 		Get,
 	},
 };
+use sp_arithmetic::traits::Unsigned;
 use sp_runtime::{AccountId32, Saturating};
 use sp_std::marker::PhantomData;
 
-impl<AccountId, BlockNumber, Metadata> SubscriptionTrait<AccountId>
+impl<AccountId, BlockNumber: Unsigned, Metadata> SubscriptionTrait<AccountId>
 	for Subscription<AccountId, BlockNumber, Metadata>
 {
 	fn subscriber(&self) -> &AccountId {

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -221,7 +221,7 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// A new subscription was created (includes single-block subscriptions)
 		SubscriptionCreated { sub_id: SubscriptionId },
-		/// A subscription has naturally finished
+		/// A subscription has finished
 		SubscriptionFinished { sub_id: SubscriptionId },
 		/// A subscription was paused
 		SubscriptionPaused { sub_id: SubscriptionId },
@@ -229,8 +229,6 @@ pub mod pallet {
 		SubscriptionUpdated { sub_id: SubscriptionId },
 		/// A subscription was reactivated
 		SubscriptionReactivated { sub_id: SubscriptionId },
-		/// A subscription has been manually finished
-		SubscriptionKilled { sub_id: SubscriptionId },
 		/// Randomness was successfully distributed
 		RandomnessDistributed { sub_id: SubscriptionId },
 		/// WARNING Subscription credit went bellow 0. This should never happen
@@ -341,7 +339,7 @@ pub mod pallet {
 				let sub = maybe_sub.take().ok_or(Error::<T>::SubscriptionDoesNotExist)?;
 				ensure!(sub.details.subscriber == subscriber, Error::<T>::NotSubscriber);
 				// TODO: refund storage and fees https://github.com/ideal-lab5/idn-sdk/issues/107
-				Self::deposit_event(Event::SubscriptionKilled { sub_id });
+				Self::deposit_event(Event::SubscriptionFinished { sub_id });
 				Ok(())
 			})
 		}

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -273,6 +273,7 @@ pub mod pallet {
 			{
 				if sub.credits_left < Zero::zero() {
 					// If this happens then there's a bug in the code
+					// TODO: log a warning that can be picked up by the monitoring system https://github.com/ideal-lab5/ideal-network/issues/28
 					Self::deposit_event(Event::SubscriptionCreditBelowZero {
 						sub_id,
 						credits: sub.credits_left,

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -53,9 +53,9 @@
 #[cfg(test)]
 mod tests;
 
+pub mod impls;
 pub mod traits;
 pub mod weights;
-// pub mod impls;
 
 use codec::{Codec, Decode, Encode, MaxEncodedLen};
 use frame_support::{
@@ -78,7 +78,7 @@ use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_io::hashing::blake2_256;
 use sp_std::fmt::Debug;
-use traits::{DepositCalculator, FeesManager};
+use traits::{DepositCalculator, FeesManager, Subscription as SubscriptionTrait};
 use xcm::{
 	v5::{prelude::*, Location},
 	VersionedLocation, VersionedXcm,
@@ -179,6 +179,7 @@ pub mod pallet {
 			BlockNumberFor<Self>,
 			SubscriptionOf<Self>,
 			DispatchError,
+			<Self as frame_system::pallet::Config>::AccountId,
 		>;
 
 		/// Storage deposit calculator implementation

--- a/pallets/idn-manager/src/tests/fee_examples.rs
+++ b/pallets/idn-manager/src/tests/fee_examples.rs
@@ -23,7 +23,7 @@ use crate::traits::FeesManager;
 /// Linear fee calculator with no discount
 pub struct LinearFeeCalculator;
 
-impl FeesManager<u32, u32, (), ()> for LinearFeeCalculator {
+impl FeesManager<u32, u32, (), (), ()> for LinearFeeCalculator {
 	fn calculate_subscription_fees(amount: u32) -> u32 {
 		let base_fee = 100u32;
 		base_fee.saturating_mul(amount.into())
@@ -41,7 +41,7 @@ impl FeesManager<u32, u32, (), ()> for LinearFeeCalculator {
 /// Tiered fee calculator with predefined discount tiers
 pub struct SteppedTieredFeeCalculator;
 
-impl FeesManager<u32, u32, (), ()> for SteppedTieredFeeCalculator {
+impl FeesManager<u32, u32, (), (), ()> for SteppedTieredFeeCalculator {
 	fn calculate_subscription_fees(amount: u32) -> u32 {
 		let base_fee = 100u32;
 

--- a/pallets/idn-manager/src/tests/fee_examples.rs
+++ b/pallets/idn-manager/src/tests/fee_examples.rs
@@ -18,12 +18,12 @@
 //!
 //! This module contains examples of fee calculators that can be used in the IDN Manager pallet.
 
-use crate::traits::FeesCalculator;
+use crate::traits::FeesManager;
 
 /// Linear fee calculator with no discount
 pub struct LinearFeeCalculator;
 
-impl FeesCalculator<u32, u32> for LinearFeeCalculator {
+impl FeesManager<u32, u32, (), ()> for LinearFeeCalculator {
 	fn calculate_subscription_fees(amount: u32) -> u32 {
 		let base_fee = 100u32;
 		base_fee.saturating_mul(amount.into())
@@ -32,12 +32,16 @@ impl FeesCalculator<u32, u32> for LinearFeeCalculator {
 		// in this case of a liner function, the refund's is the same as the fees'
 		Self::calculate_subscription_fees(current_amount)
 	}
+	fn collect_fees(fees: u32, _: ()) -> Result<u32, crate::traits::FeesError<u32, ()>> {
+		// In this case, we don't need to do anything with the fees, so we just return them
+		Ok(fees)
+	}
 }
 
 /// Tiered fee calculator with predefined discount tiers
 pub struct SteppedTieredFeeCalculator;
 
-impl FeesCalculator<u32, u32> for SteppedTieredFeeCalculator {
+impl FeesManager<u32, u32, (), ()> for SteppedTieredFeeCalculator {
 	fn calculate_subscription_fees(amount: u32) -> u32 {
 		let base_fee = 100u32;
 
@@ -81,6 +85,10 @@ impl FeesCalculator<u32, u32> for SteppedTieredFeeCalculator {
 		let used_amount = init_amount - current_amount;
 		Self::calculate_subscription_fees(init_amount) -
 			Self::calculate_subscription_fees(used_amount)
+	}
+	fn collect_fees(fees: u32, _: ()) -> Result<u32, crate::traits::FeesError<u32, ()>> {
+		// In this case, we don't need to do anything with the fees, so we just return them
+		Ok(fees)
 	}
 }
 

--- a/pallets/idn-manager/src/tests/fee_examples.rs
+++ b/pallets/idn-manager/src/tests/fee_examples.rs
@@ -29,7 +29,7 @@ impl FeesManager<u32, u32, (), (), ()> for LinearFeeCalculator {
 		base_fee.saturating_mul(amount.into())
 	}
 	fn calculate_refund_fees(_init_amount: u32, current_amount: u32) -> u32 {
-		// in this case of a liner function, the refund's is the same as the fees'
+		// in this case of a linear function, the refund's is the same as the fees'
 		Self::calculate_subscription_fees(current_amount)
 	}
 	fn collect_fees(fees: u32, _: ()) -> Result<u32, crate::traits::FeesError<u32, ()>> {

--- a/pallets/idn-manager/src/tests/mock.rs
+++ b/pallets/idn-manager/src/tests/mock.rs
@@ -61,6 +61,7 @@ parameter_types! {
 	pub const PalletId: frame_support::PalletId = frame_support::PalletId(*b"idn_mngr");
 	pub const TreasuryAccount: AccountId32 = AccountId32::new([1u8; 32]);
 	pub const BaseFee: u64 = 10;
+	pub const SDMultiplier: u64 = 10;
 }
 
 #[derive(TypeInfo)]
@@ -77,7 +78,7 @@ impl pallet_idn_manager::Config for Test {
 	type Currency = Balances;
 	type FeesManager =
 		FeesManagerImpl<TreasuryAccount, BaseFee, SubscriptionOf<Test>, BlockNumber, Balances>;
-	type DepositCalculator = DepositCalculatorImpl;
+	type DepositCalculator = DepositCalculatorImpl<SDMultiplier, u64>;
 	type PalletId = PalletId;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type Rnd = [u8; 32];

--- a/pallets/idn-manager/src/tests/mock.rs
+++ b/pallets/idn-manager/src/tests/mock.rs
@@ -87,7 +87,13 @@ impl pallet_idn_manager::Config for Test {
 	type SubMetadataLen = SubMetadataLen;
 }
 
-pub fn new_test_ext() -> sp_io::TestExternalities {
-	let t = system::GenesisConfig::<Test>::default().build_storage().unwrap();
-	t.into()
+pub struct ExtBuilder;
+
+impl ExtBuilder {
+	pub fn build() -> sp_io::TestExternalities {
+		let storage = system::GenesisConfig::<Test>::default().build_storage().unwrap();
+		let mut ext = sp_io::TestExternalities::new(storage);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
 }

--- a/pallets/idn-manager/src/tests/mock.rs
+++ b/pallets/idn-manager/src/tests/mock.rs
@@ -19,13 +19,23 @@
 //! This file is a mock runtime for the pallet. It is used to test the pallet in a test environment.
 //! It does not contain any tests.
 
-use crate as pallet_idn_manager;
+use crate::{self as pallet_idn_manager, traits::FeesError, HoldReason, SubscriptionOf};
 use codec::{Decode, Encode};
 use frame_support::{
-	construct_runtime, derive_impl, parameter_types, sp_runtime::BuildStorage, traits::Get,
+	construct_runtime, derive_impl,
+	pallet_prelude::DispatchError,
+	parameter_types,
+	sp_runtime::BuildStorage,
+	traits::{
+		fungible::MutateHold,
+		tokens::{Fortitude, Precision, Restriction},
+		Get,
+	},
 };
 use frame_system as system;
 use scale_info::TypeInfo;
+use sp_runtime::{traits::IdentityLookup, AccountId32};
+use sp_std::marker::PhantomData;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 type BlockNumber = frame_system::pallet_prelude::BlockNumberFor<Test>;
@@ -42,6 +52,8 @@ construct_runtime!(
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
 impl frame_system::Config for Test {
 	type Block = Block;
+	type AccountId = AccountId32;
+	type Lookup = IdentityLookup<Self::AccountId>;
 	type AccountData = pallet_balances::AccountData<u64>;
 }
 
@@ -53,12 +65,14 @@ impl pallet_balances::Config for Test {
 parameter_types! {
 	pub const MaxSubscriptionDuration: u64 = 100;
 	pub const PalletId: frame_support::PalletId = frame_support::PalletId(*b"idn_mngr");
+	pub const TreasuryAccount: AccountId32 = AccountId32::new([1u8; 32]);
+	pub const BaseFee: u64 = 10;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Encode, Decode, TypeInfo, Default)]
-pub struct SubMetadataLenWrapper;
+pub struct SubMetadataLen;
 
-impl Get<u32> for SubMetadataLenWrapper {
+impl Get<u32> for SubMetadataLen {
 	fn get() -> u32 {
 		8
 	}
@@ -67,26 +81,55 @@ impl Get<u32> for SubMetadataLenWrapper {
 impl pallet_idn_manager::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
-	type FeesCalculator = FeesCalculatorImpl;
+	type FeesManager = FeesManagerImpl<TreasuryAccount, BaseFee>;
 	type DepositCalculator = DepositCalculatorImpl;
 	type PalletId = PalletId;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type Rnd = [u8; 32];
 	type WeightInfo = ();
 	type Xcm = ();
-	type SubMetadataLen = SubMetadataLenWrapper;
+	type SubMetadataLen = SubMetadataLen;
 }
 
-pub struct FeesCalculatorImpl;
+/// A FeesManager implementation that holds a dynamic treasury account.
+pub struct FeesManagerImpl<Treasury: Get<AccountId32>, BaseFee: Get<u64>> {
+	pub _phantom: (PhantomData<Treasury>, PhantomData<BaseFee>),
+}
 
-impl pallet_idn_manager::FeesCalculator<u64, BlockNumber> for FeesCalculatorImpl {
+impl<T: Get<AccountId32>, B: Get<u64>>
+	pallet_idn_manager::FeesManager<u64, BlockNumber, SubscriptionOf<Test>, DispatchError>
+	for FeesManagerImpl<T, B>
+{
 	fn calculate_subscription_fees(amount: BlockNumber) -> u64 {
-		let base_fee = 10u64;
+		let base_fee = B::get();
 		base_fee.saturating_mul(amount.into())
 	}
 	fn calculate_refund_fees(_init_amount: BlockNumber, current_amount: BlockNumber) -> u64 {
 		// in this case of a liner function, the refund's is the same as the fees'
 		Self::calculate_subscription_fees(current_amount)
+	}
+	fn collect_fees(
+		fees: u64,
+		sub: SubscriptionOf<Test>,
+	) -> Result<u64, FeesError<u64, DispatchError>> {
+		// Collect the held fees from the subscriber
+		let collected = Balances::transfer_on_hold(
+			&HoldReason::Fees.into(),
+			&sub.details.subscriber,
+			&T::get(),
+			fees,
+			Precision::BestEffort,
+			Restriction::Free,
+			Fortitude::Polite,
+		)
+		.map_err(|e| FeesError::Other(e))?;
+
+		// Ensure the correct amount was collected.
+		if collected < fees {
+			return Err(FeesError::NotEnoughBalance { needed: fees, balance: collected });
+		}
+
+		Ok(collected)
 	}
 }
 

--- a/pallets/idn-manager/src/tests/pallet.rs
+++ b/pallets/idn-manager/src/tests/pallet.rs
@@ -17,7 +17,6 @@
 //! # Tests for the IDN Manager pallet
 
 use crate::{
-	impls::DepositCalculatorImpl,
 	tests::mock::{new_test_ext, Balances, Test, *},
 	traits::{DepositCalculator, FeesManager},
 	Config, Error, HoldReason, SubscriptionState, Subscriptions,
@@ -59,7 +58,7 @@ fn create_subscription_works() {
 
 		// assert that the correct fees have been held
 		let fees = <Test as Config>::FeesManager::calculate_subscription_fees(amount);
-		let deposit = DepositCalculatorImpl::calculate_storage_deposit(&subscription);
+		let deposit = <Test as Config>::DepositCalculator::calculate_storage_deposit(&subscription);
 		assert_eq!(Balances::free_balance(&subscriber), initial_balance - fees - deposit);
 		assert_eq!(Balances::balance_on_hold(&HoldReason::Fees.into(), &subscriber), fees);
 		assert_eq!(
@@ -192,7 +191,8 @@ fn test_update_subscription() {
 
 		let original_fees =
 			<Test as Config>::FeesManager::calculate_subscription_fees(original_amount);
-		let original_deposit = DepositCalculatorImpl::calculate_storage_deposit(&subscription);
+		let original_deposit =
+			<Test as Config>::DepositCalculator::calculate_storage_deposit(&subscription);
 		let balance_after_create = initial_balance - original_fees - original_deposit;
 
 		// assert correct balance on subscriber after creating subscription

--- a/pallets/idn-manager/src/tests/pallet.rs
+++ b/pallets/idn-manager/src/tests/pallet.rs
@@ -27,26 +27,29 @@ use frame_support::{
 	BoundedVec,
 };
 use idn_traits::rand::Dispatcher;
+use sp_core::H256;
 use sp_runtime::AccountId32;
 use xcm::v5::{Junction, Location};
+
+const ALICE: AccountId32 = AccountId32::new([1u8; 32]);
+const BOB: AccountId32 = AccountId32::new([2u8; 32]);
 
 #[test]
 fn create_subscription_works() {
 	new_test_ext().execute_with(|| {
-		let subscriber: AccountId32 = [1u8; 32].into();
 		let amount: u64 = 50;
 		let target = Location::new(1, [Junction::PalletInstance(1)]);
 		let frequency: u64 = 10;
 		let initial_balance = 10_000_000;
 
-		<Test as Config>::Currency::set_balance(&subscriber, initial_balance);
+		<Test as Config>::Currency::set_balance(&ALICE, initial_balance);
 
 		// assert Subscriptions storage map is empty before creating a subscription
 		assert_eq!(Subscriptions::<Test>::iter().count(), 0);
 
 		// assert that the subscription has been created
 		assert_ok!(IdnManager::create_subscription(
-			RuntimeOrigin::signed(subscriber.clone()),
+			RuntimeOrigin::signed(ALICE.clone()),
 			amount,
 			target.clone(),
 			frequency,
@@ -59,15 +62,12 @@ fn create_subscription_works() {
 		// assert that the correct fees have been held
 		let fees = <Test as Config>::FeesManager::calculate_subscription_fees(amount);
 		let deposit = <Test as Config>::DepositCalculator::calculate_storage_deposit(&subscription);
-		assert_eq!(Balances::free_balance(&subscriber), initial_balance - fees - deposit);
-		assert_eq!(Balances::balance_on_hold(&HoldReason::Fees.into(), &subscriber), fees);
-		assert_eq!(
-			Balances::balance_on_hold(&HoldReason::StorageDeposit.into(), &subscriber),
-			deposit
-		);
+		assert_eq!(Balances::free_balance(&ALICE), initial_balance - fees - deposit);
+		assert_eq!(Balances::balance_on_hold(&HoldReason::Fees.into(), &ALICE), fees);
+		assert_eq!(Balances::balance_on_hold(&HoldReason::StorageDeposit.into(), &ALICE), deposit);
 
 		// assert that the subscription details are correct
-		assert_eq!(subscription.details.subscriber, subscriber);
+		assert_eq!(subscription.details.subscriber, ALICE);
 		assert_eq!(subscription.details.amount, amount);
 		assert_eq!(subscription.details.target, target);
 		assert_eq!(subscription.details.frequency, frequency);
@@ -81,16 +81,15 @@ fn create_subscription_works() {
 #[test]
 fn create_subscription_fails_if_insufficient_balance() {
 	new_test_ext().execute_with(|| {
-		let subscriber: AccountId32 = [1u8; 32].into();
 		let amount: u64 = 50;
 		let target = Location::new(1, [Junction::PalletInstance(1)]);
 		let frequency: u64 = 10;
 
-		<Test as Config>::Currency::set_balance(&subscriber, 10);
+		<Test as Config>::Currency::set_balance(&ALICE, 10);
 
 		assert_noop!(
 			IdnManager::create_subscription(
-				RuntimeOrigin::signed(subscriber),
+				RuntimeOrigin::signed(ALICE),
 				amount,
 				target,
 				frequency,
@@ -102,19 +101,48 @@ fn create_subscription_fails_if_insufficient_balance() {
 }
 
 #[test]
-// Todo: https://github.com/ideal-lab5/idn-sdk/issues/77
-#[ignore]
-fn distribute_randomness_works() {
+fn create_subscription_fails_if_sub_already_exists() {
 	new_test_ext().execute_with(|| {
-		let subscriber: AccountId32 = [1u8; 32].into();
 		let amount: u64 = 50;
 		let target = Location::new(1, [Junction::PalletInstance(1)]);
 		let frequency: u64 = 10;
 
-		<Test as Config>::Currency::set_balance(&subscriber, 10_000_000);
+		<Test as Config>::Currency::set_balance(&ALICE, 10_000_000);
 
 		assert_ok!(IdnManager::create_subscription(
-			RuntimeOrigin::signed(subscriber),
+			RuntimeOrigin::signed(ALICE.clone()),
+			amount,
+			target.clone(),
+			frequency,
+			None
+		));
+
+		assert_noop!(
+			IdnManager::create_subscription(
+				RuntimeOrigin::signed(ALICE),
+				amount,
+				target,
+				frequency,
+				None
+			),
+			Error::<Test>::SubscriptionAlreadyExists
+		);
+	});
+}
+
+#[test]
+// Todo: https://github.com/ideal-lab5/idn-sdk/issues/77
+#[ignore]
+fn distribute_randomness_works() {
+	new_test_ext().execute_with(|| {
+		let amount: u64 = 50;
+		let target = Location::new(1, [Junction::PalletInstance(1)]);
+		let frequency: u64 = 10;
+
+		<Test as Config>::Currency::set_balance(&ALICE, 10_000_000);
+
+		assert_ok!(IdnManager::create_subscription(
+			RuntimeOrigin::signed(ALICE),
 			amount,
 			target.clone(),
 			frequency,
@@ -136,16 +164,15 @@ fn distribute_randomness_works() {
 #[test]
 fn test_kill_subscription() {
 	new_test_ext().execute_with(|| {
-		let subscriber: AccountId32 = [1u8; 32].into();
 		let amount = 10;
 		let frequency = 2;
 		let target = Location::new(1, [Junction::PalletInstance(1)]);
 		let metadata = None;
 
-		<Test as Config>::Currency::set_balance(&subscriber, 10_000_000);
+		<Test as Config>::Currency::set_balance(&ALICE, 10_000_000);
 
 		assert_ok!(IdnManager::create_subscription(
-			RuntimeOrigin::signed(subscriber.clone()),
+			RuntimeOrigin::signed(ALICE.clone()),
 			amount,
 			target.clone(),
 			frequency,
@@ -158,15 +185,26 @@ fn test_kill_subscription() {
 		// - correct storage deposit is refunded
 		// - correct fees were collected
 		// https://github.com/ideal-lab5/idn-sdk/issues/107
-		assert_ok!(IdnManager::kill_subscription(RuntimeOrigin::signed(subscriber), sub_id));
+		assert_ok!(IdnManager::kill_subscription(RuntimeOrigin::signed(ALICE), sub_id));
 		assert!(Subscriptions::<Test>::get(sub_id).is_none());
+	});
+}
+
+#[test]
+fn kill_subscription_fails_if_sub_does_not_exist() {
+	new_test_ext().execute_with(|| {
+		let sub_id = H256::from_slice(&[1; 32]);
+
+		assert_noop!(
+			IdnManager::kill_subscription(RuntimeOrigin::signed(ALICE), sub_id),
+			Error::<Test>::SubscriptionDoesNotExist
+		);
 	});
 }
 
 #[test]
 fn test_update_subscription() {
 	new_test_ext().execute_with(|| {
-		let subscriber: AccountId32 = [1u8; 32].into();
 		let original_amount = 10;
 		let original_frequency = 2;
 		// TODO as part of https://github.com/ideal-lab5/idn-sdk/issues/104
@@ -177,10 +215,10 @@ fn test_update_subscription() {
 		let metadata = None;
 		let initial_balance = 10_000_000;
 
-		<Test as Config>::Currency::set_balance(&subscriber, initial_balance);
+		<Test as Config>::Currency::set_balance(&ALICE, initial_balance);
 
 		assert_ok!(IdnManager::create_subscription(
-			RuntimeOrigin::signed(subscriber.clone()),
+			RuntimeOrigin::signed(ALICE.clone()),
 			original_amount,
 			target.clone(),
 			original_frequency,
@@ -196,15 +234,15 @@ fn test_update_subscription() {
 		let balance_after_create = initial_balance - original_fees - original_deposit;
 
 		// assert correct balance on subscriber after creating subscription
-		assert_eq!(Balances::free_balance(&subscriber), balance_after_create);
-		assert_eq!(Balances::balance_on_hold(&HoldReason::Fees.into(), &subscriber), original_fees);
+		assert_eq!(Balances::free_balance(&ALICE), balance_after_create);
+		assert_eq!(Balances::balance_on_hold(&HoldReason::Fees.into(), &ALICE), original_fees);
 		assert_eq!(
-			Balances::balance_on_hold(&HoldReason::StorageDeposit.into(), &subscriber),
+			Balances::balance_on_hold(&HoldReason::StorageDeposit.into(), &ALICE),
 			original_deposit
 		);
 
 		assert_ok!(IdnManager::update_subscription(
-			RuntimeOrigin::signed(subscriber),
+			RuntimeOrigin::signed(ALICE),
 			sub_id,
 			new_amount,
 			new_frequency
@@ -220,6 +258,24 @@ fn test_update_subscription() {
 	});
 }
 
+#[test]
+fn update_subscription_fails_if_sub_does_not_exists() {
+	new_test_ext().execute_with(|| {
+		let sub_id = H256::from_slice(&[1; 32]);
+		let new_amount = 20;
+		let new_frequency = 4;
+
+		assert_noop!(
+			IdnManager::update_subscription(
+				RuntimeOrigin::signed(ALICE),
+				sub_id,
+				new_amount,
+				new_frequency
+			),
+			Error::<Test>::SubscriptionDoesNotExist
+		);
+	});
+}
 // todo: test credits consumption, it consumes credit by credit and verify that
 // - fees are moved to treasury
 // - credits are consumed
@@ -230,40 +286,173 @@ fn test_update_subscription() {
 #[test]
 fn test_pause_reactivate_subscription() {
 	new_test_ext().execute_with(|| {
-		let subscriber: AccountId32 = [1u8; 32].into();
 		let amount = 10;
 		let frequency = 2;
 		let target = Location::new(1, [Junction::PalletInstance(1)]);
 		let metadata = None;
 
-		<Test as Config>::Currency::set_balance(&subscriber, 10_000_000);
+		<Test as Config>::Currency::set_balance(&ALICE, 10_000_000);
 
 		assert_ok!(IdnManager::create_subscription(
-			RuntimeOrigin::signed(subscriber.clone()),
+			RuntimeOrigin::signed(ALICE.clone()),
 			amount,
 			target.clone(),
 			frequency,
 			metadata.clone()
 		));
 
-		let free_balance = Balances::free_balance(&subscriber);
+		let free_balance = Balances::free_balance(&ALICE);
 
 		let (sub_id, _) = Subscriptions::<Test>::iter().next().unwrap();
 
 		// Test pause and reactivate subscription
-		assert_ok!(IdnManager::pause_subscription(
-			RuntimeOrigin::signed(subscriber.clone()),
-			sub_id
-		));
+		assert_ok!(IdnManager::pause_subscription(RuntimeOrigin::signed(ALICE.clone()), sub_id));
 		assert_eq!(Subscriptions::<Test>::get(sub_id).unwrap().state, SubscriptionState::Paused);
 		assert_ok!(IdnManager::reactivate_subscription(
-			RuntimeOrigin::signed(subscriber.clone()),
+			RuntimeOrigin::signed(ALICE.clone()),
 			sub_id
 		));
 		assert_eq!(Subscriptions::<Test>::get(sub_id).unwrap().state, SubscriptionState::Active);
 
 		// Assert current free balance is the same as the free balance before pausing and
 		// reactivating
-		assert_eq!(Balances::free_balance(&subscriber), free_balance);
+		assert_eq!(Balances::free_balance(&ALICE), free_balance);
+	});
+}
+
+#[test]
+fn pause_subscription_fails_if_sub_does_not_exists() {
+	new_test_ext().execute_with(|| {
+		let sub_id = H256::from_slice(&[1; 32]);
+
+		assert_noop!(
+			IdnManager::pause_subscription(RuntimeOrigin::signed(ALICE), sub_id),
+			Error::<Test>::SubscriptionDoesNotExist
+		);
+	});
+}
+
+#[test]
+fn pause_subscription_fails_if_sub_already_paused() {
+	new_test_ext().execute_with(|| {
+		let amount = 10;
+		let frequency = 2;
+		let target = Location::new(1, [Junction::PalletInstance(1)]);
+		let metadata = None;
+
+		<Test as Config>::Currency::set_balance(&ALICE, 10_000_000);
+
+		assert_ok!(IdnManager::create_subscription(
+			RuntimeOrigin::signed(ALICE.clone()),
+			amount,
+			target.clone(),
+			frequency,
+			metadata.clone()
+		));
+
+		let (sub_id, _) = Subscriptions::<Test>::iter().next().unwrap();
+
+		assert_ok!(IdnManager::pause_subscription(RuntimeOrigin::signed(ALICE.clone()), sub_id));
+		assert_noop!(
+			IdnManager::pause_subscription(RuntimeOrigin::signed(ALICE), sub_id),
+			Error::<Test>::SubscriptionAlreadyPaused
+		);
+	});
+}
+
+#[test]
+fn reactivate_subscription_fails_if_sub_does_not_exists() {
+	new_test_ext().execute_with(|| {
+		let sub_id = H256::from_slice(&[1; 32]);
+
+		assert_noop!(
+			IdnManager::reactivate_subscription(RuntimeOrigin::signed(ALICE), sub_id),
+			Error::<Test>::SubscriptionDoesNotExist
+		);
+	});
+}
+
+#[test]
+fn reactivate_subscriptio_fails_if_sub_already_active() {
+	new_test_ext().execute_with(|| {
+		let amount = 10;
+		let frequency = 2;
+		let target = Location::new(1, [Junction::PalletInstance(1)]);
+		let metadata = None;
+
+		<Test as Config>::Currency::set_balance(&ALICE, 10_000_000);
+
+		assert_ok!(IdnManager::create_subscription(
+			RuntimeOrigin::signed(ALICE.clone()),
+			amount,
+			target.clone(),
+			frequency,
+			metadata.clone()
+		));
+
+		let (sub_id, _) = Subscriptions::<Test>::iter().next().unwrap();
+
+		assert_noop!(
+			IdnManager::reactivate_subscription(RuntimeOrigin::signed(ALICE), sub_id),
+			Error::<Test>::SubscriptionAlreadyActive
+		);
+	});
+}
+
+#[test]
+fn operations_fail_if_origin_is_not_the_subscriber() {
+	new_test_ext().execute_with(|| {
+		let amount: u64 = 50;
+		let target = Location::new(1, [Junction::PalletInstance(1)]);
+		let frequency: u64 = 10;
+		let metadata = None;
+		let initial_balance = 10_000_000;
+
+		// Set balance for Alice and Bob
+		<Test as Config>::Currency::set_balance(&ALICE, initial_balance);
+		<Test as Config>::Currency::set_balance(&BOB, initial_balance);
+
+		// Create subscription for Alice
+		assert_ok!(IdnManager::create_subscription(
+			RuntimeOrigin::signed(ALICE.clone()),
+			amount,
+			target.clone(),
+			frequency,
+			metadata.clone()
+		));
+
+		// Retrieve the subscription ID created
+		let (sub_id, _) = Subscriptions::<Test>::iter().next().unwrap();
+
+		// Attempt to kill the subscription using Bob's origin (should fail)
+		assert_noop!(
+			IdnManager::kill_subscription(RuntimeOrigin::signed(BOB.clone()), sub_id),
+			Error::<Test>::NotSubscriber
+		);
+
+		// Attempt to pause the subscription using Bob's origin (should fail)
+		assert_noop!(
+			IdnManager::pause_subscription(RuntimeOrigin::signed(BOB.clone()), sub_id),
+			Error::<Test>::NotSubscriber
+		);
+
+		// Attempt to update the subscription using Bob's origin (should fail)
+		let new_amount = amount + 10;
+		let new_frequency = frequency + 1;
+		assert_noop!(
+			IdnManager::update_subscription(
+				RuntimeOrigin::signed(BOB.clone()),
+				sub_id,
+				new_amount,
+				new_frequency
+			),
+			Error::<Test>::NotSubscriber
+		);
+
+		// Attempt to reactivate the subscription using Bob's origin (should fail)
+		assert_noop!(
+			IdnManager::reactivate_subscription(RuntimeOrigin::signed(BOB.clone()), sub_id),
+			Error::<Test>::NotSubscriber
+		);
 	});
 }

--- a/pallets/idn-manager/src/tests/pallet.rs
+++ b/pallets/idn-manager/src/tests/pallet.rs
@@ -211,22 +211,6 @@ fn test_update_subscription() {
 		));
 
 		// TODO implement a way to refund or take the difference in fees https://github.com/ideal-lab5/idn-sdk/issues/104
-		// let new_fees = FeesManagerImpl::calculate_subscription_fees(new_amount);
-		// let new_deposit = DepositCalculatorImpl::calculate_storage_deposit(&subscription);
-
-		// let fees_diff = new_fees - original_fees;
-		// let deposit_diff = new_deposit - original_deposit;
-
-		// let balance_after_update = balance_after_create - fees_diff - deposit_diff;
-
-		// // assert correct balances after update
-		// assert_eq!(Balances::free_balance(&subscriber), balance_after_update);
-		// assert_eq!(Balances::balance_on_hold(&HoldReason::Fees.into(), &subscriber), new_fees);
-		// assert_eq!(
-		// 	Balances::balance_on_hold(&HoldReason::StorageDeposit.into(), &subscriber),
-		// 	new_deposit
-		// );
-		// assert_eq!(balance_after_update + new_fees + new_deposit, initial_balance);
 
 		let subscription = Subscriptions::<Test>::get(sub_id).unwrap();
 

--- a/pallets/idn-manager/src/tests/pallet.rs
+++ b/pallets/idn-manager/src/tests/pallet.rs
@@ -17,7 +17,8 @@
 //! # Tests for the IDN Manager pallet
 
 use crate::{
-	tests::mock::{new_test_ext, Balances, DepositCalculatorImpl, Test, *},
+	impls::DepositCalculatorImpl,
+	tests::mock::{new_test_ext, Balances, Test, *},
 	traits::{DepositCalculator, FeesManager},
 	Config, Error, HoldReason, SubscriptionState, Subscriptions,
 };

--- a/pallets/idn-manager/src/traits.rs
+++ b/pallets/idn-manager/src/traits.rs
@@ -16,16 +16,26 @@
 
 //! # Traits
 
-/// Trait for fees calculation
-///
-/// This trait is used to calculate the fees for a subscription based on the amount of random values
-/// required by the subscription.
-pub trait FeesCalculator<Fees, Amount> {
+pub enum FeesError<Fees, E> {
+	NotEnoughBalance { needed: Fees, balance: Fees },
+	Other(E),
+}
+/// Trait for fees managing
+pub trait FeesManager<Fees, Amount, Sub, E> {
 	/// Calculate the fees for a subscription based on the amount of random values required.
 	fn calculate_subscription_fees(amount: Amount) -> Fees;
 	/// Calculate how much fees should be refunded for a subscription that is being cancelled.
 	fn calculate_refund_fees(init_amount: Amount, current_amount: Amount) -> Fees;
+	/// Distributes collected fees. Returns the fees that were effectively collected.
+	fn collect_fees(fees: Fees, sub: Sub) -> Result<Fees, FeesError<Fees, E>>;
 }
+
+// pub trait SubscriptionDetails {}
+
+// pub trait Subscription {
+// 	type SubscriptionDetails;
+// 	fn details(&self) -> Self::SubscriptionDetails;
+// }
 
 /// Trait for storage deposit calculation
 ///

--- a/pallets/idn-manager/src/traits.rs
+++ b/pallets/idn-manager/src/traits.rs
@@ -21,21 +21,18 @@ pub enum FeesError<Fees, E> {
 	Other(E),
 }
 /// Trait for fees managing
-pub trait FeesManager<Fees, Amount, Sub, E> {
+pub trait FeesManager<Fees, Amount, Sub: Subscription<S>, Err, S> {
 	/// Calculate the fees for a subscription based on the amount of random values required.
 	fn calculate_subscription_fees(amount: Amount) -> Fees;
 	/// Calculate how much fees should be refunded for a subscription that is being cancelled.
 	fn calculate_refund_fees(init_amount: Amount, current_amount: Amount) -> Fees;
 	/// Distributes collected fees. Returns the fees that were effectively collected.
-	fn collect_fees(fees: Fees, sub: Sub) -> Result<Fees, FeesError<Fees, E>>;
+	fn collect_fees(fees: Fees, sub: Sub) -> Result<Fees, FeesError<Fees, Err>>;
 }
 
-// pub trait SubscriptionDetails {}
-
-// pub trait Subscription {
-// 	type SubscriptionDetails;
-// 	fn details(&self) -> Self::SubscriptionDetails;
-// }
+pub trait Subscription<Subscriber> {
+	fn subscriber(&self) -> &Subscriber;
+}
 
 /// Trait for storage deposit calculation
 ///

--- a/pallets/idn-manager/src/traits.rs
+++ b/pallets/idn-manager/src/traits.rs
@@ -16,9 +16,12 @@
 
 //! # Traits
 
-pub enum FeesError<Fees, E> {
+/// Error type for fees management
+///
+/// Context is used to provide more information about uncategorized errors.
+pub enum FeesError<Fees, Context> {
 	NotEnoughBalance { needed: Fees, balance: Fees },
-	Other(E),
+	Other(Context),
 }
 /// Trait for fees managing
 pub trait FeesManager<Fees, Amount, Sub: Subscription<S>, Err, S> {


### PR DESCRIPTION
I have created the collection logic as trait implementation, as the actual logic is left for the runtime implementation.
This logic though has been made such as it can be used in production by implementing its generics.
Tests will be added as part of the behaviour implementation of #107 and #104

closes #108 
closes #113 