### PR TITLE
Set MaxSigsPerBlock and configure genesis

### DIFF
--- a/pallets/randomness-beacon/src/mock.rs
+++ b/pallets/randomness-beacon/src/mock.rs
@@ -63,7 +63,7 @@ impl pallet_drand_bridge::Config for Test {
 	type WeightInfo = ();
 	type BeaconConfig = QuicknetBeaconConfig;
 	type SignatureAggregator = QuicknetAggregator;
-	type SignatureToBlockRatio = ConstU8<2>;
+	type MaxSigsPerBlock = ConstU8<2>;
 }
 
 // Build genesis storage according to the mock runtime.


### PR DESCRIPTION
This PR sets a maximum number of drand rounds we can aggregate and ingest per block. In addition it ensures that the genesis round is configured with the first call from the inherent. 

- closes #127 
- closes #123 