### PR TITLE
Update Code Coverage Tools

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - cki/code-coverage
   pull_request:
     branches:
       - main

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       run: cargo install cargo-llvm-cov
 
     - name: run cargo-llvm-cov
-      run: cargo llvm-cov --output-path lcov.info
+      run: cargo llvm-cov --cobertura --output-path cobertura.xml
 
     - name: Generate Code Coverage Summary
       uses: irongut/CodeCoverageSummary@v1.3.0
@@ -64,14 +64,6 @@ jobs:
         thresholds: '50 85'
         output: both
         format: markdown
-    - name: Setup LCOV
-      uses: hrishikesh-kadam/setup-lcov@v1
-    - name: Report code coverage
-      uses: zgosalvez/github-actions-report-lcov@v4
-      with:
-        coverage-files: lcov.info
-        minimum-coverage: 50
-        artifact-name: code-coverage-results
 
     - name: Export Job Summary
       run: echo "$(<code-coverage-results)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,10 @@ jobs:
         override: false
 
     - name: Install rustfmt for nightly
-      run: rustup component add --toolchain nightly rustfmt llvm-tools-preview
+      run: rustup component add --toolchain nightly rustfmt
+
+    - name: Install llvm-tools-preview for stable
+      run: rustup component add llvm-tools-preview --toolchain stable-x86_64-unknown-linux-gnu
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,4 +66,4 @@ jobs:
         format: markdown
 
     - name: Export Job Summary
-      run: echo "$(<code-coverage-results)" >> $GITHUB_STEP_SUMMARY
+      run: echo "$(<code-coverage-results.md)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,8 +49,9 @@ jobs:
     - name: Run cargo clippy
       run: cargo clippy -- -D warnings
 
-    - name: Install llvm-cov and nextest
+    - name: Install llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
+    - name: Install nextest
       uses: taiki-e/install-action@nextest
 
     - name: Run cargo-llvm-cov and nextest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,11 +49,11 @@ jobs:
     - name: Run cargo clippy
       run: cargo clippy -- -D warnings
     
-    - name: Install cargo-llvm-cov
-      run: cargo install cargo-llvm-cov
+    - name: Install cargo-llvm-cov and nextest
+      run: cargo install cargo-llvm-cov --locked cargo-nextest
 
-    - name: run cargo-llvm-cov
-      run: cargo llvm-cov --cobertura --output-path cobertura.xml
+    - name: run cargo-llvm-cov and nextest
+      run: cargo llvm-cov --cobertura --output-path cobertura.xml nextest
 
     - name: Generate Code Coverage Summary
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,9 +48,6 @@ jobs:
 
     - name: Run cargo clippy
       run: cargo clippy -- -D warnings
-
-    - name: Install cargo-tarpaulin
-      run: cargo install cargo-tarpaulin
     
     - name: Install cargo-llvm-cov
       run: cargo install caro-llvm-cov

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,11 +48,12 @@ jobs:
 
     - name: Run cargo clippy
       run: cargo clippy -- -D warnings
-    
-    - name: Install cargo-llvm-cov and nextest
-      run: cargo install cargo-llvm-cov --locked cargo-nextest
 
-    - name: run cargo-llvm-cov and nextest
+    - name: Install llvm-cov and nextest
+      uses: taiki-e/install-action@cargo-llvm-cov
+      uses: taiki-e/install-action@nextest
+
+    - name: Run cargo-llvm-cov and nextest
       run: cargo llvm-cov --cobertura --output-path cobertura.xml nextest
 
     - name: Generate Code Coverage Summary
@@ -61,7 +62,7 @@ jobs:
         filename: cobertura.xml
         badge: true
         fail_below_min: true
-        thresholds: '50 85'
+        thresholds: '85 90'
         output: both
         format: markdown
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - cki/code-coverage
   pull_request:
     branches:
       - main
@@ -50,9 +51,11 @@ jobs:
 
     - name: Install cargo-tarpaulin
       run: cargo install cargo-tarpaulin
-
-    - name: Run cargo tarpaulin
-      run: cargo tarpaulin --rustflags="-C opt-level=0" --no-fail-fast --out xml
+    
+    - name: Install cargo-llvm-cov
+      run: cargo install caro-llvm-cov
+    - name: run cargo-llvm-cov
+      run: cargo llvm-cov report --cobertura --output-path cobertura.xml
 
     - name: Generate Code Coverage Summary
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,9 +50,10 @@ jobs:
       run: cargo clippy -- -D warnings
     
     - name: Install cargo-llvm-cov
-      run: cargo install caro-llvm-cov
+      run: cargo install cargo-llvm-cov
+
     - name: run cargo-llvm-cov
-      run: cargo llvm-cov report --cobertura --output-path cobertura.xml
+      run: cargo llvm-cov --output-path cobertura.xml
 
     - name: Generate Code Coverage Summary
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
         override: false
 
     - name: Install rustfmt for nightly
-      run: rustup component add --toolchain nightly rustfmt
+      run: rustup component add --toolchain nightly rustfmt llvm-tools
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
         override: false
 
     - name: Install rustfmt for nightly
-      run: rustup component add --toolchain nightly rustfmt llvm-tools
+      run: rustup component add --toolchain nightly rustfmt llvm-tools-preview
 
     - name: Install dependencies
       run: |
@@ -51,10 +51,11 @@ jobs:
 
     - name: Install llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
+
     - name: Install nextest
       uses: taiki-e/install-action@nextest
 
-    - name: Run cargo-llvm-cov and nextest
+    - name: Run Tests
       run: cargo llvm-cov --cobertura --output-path cobertura.xml nextest
 
     - name: Generate Code Coverage Summary

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
       run: cargo install cargo-llvm-cov
 
     - name: run cargo-llvm-cov
-      run: cargo llvm-cov --output-path cobertura.xml
+      run: cargo llvm-cov --output-path lcov.info
 
     - name: Generate Code Coverage Summary
       uses: irongut/CodeCoverageSummary@v1.3.0
@@ -64,6 +64,14 @@ jobs:
         thresholds: '50 85'
         output: both
         format: markdown
+    - name: Setup LCOV
+      uses: hrishikesh-kadam/setup-lcov@v1
+    - name: Report code coverage
+      uses: zgosalvez/github-actions-report-lcov@v4
+      with:
+        coverage-files: lcov.info
+        minimum-coverage: 50
+        artifact-name: code-coverage-results
 
     - name: Export Job Summary
-      run: echo "$(<code-coverage-results.md)" >> $GITHUB_STEP_SUMMARY
+      run: echo "$(<code-coverage-results)" >> $GITHUB_STEP_SUMMARY

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,5 +1,0 @@
-# https://github.com/xd009642/tarpaulin/blob/develop/tarpaulin.toml
-[test_config]
-
-# List of file paths to exclude from testing.
-exclude-files = ["solochain/*", "pallets/drand/examples/solochain/*", "*/**/weights.rs"]


### PR DESCRIPTION
This PR updates the test runner from tarpaulin to nextest, changes the code coverage tool to llvm-cov, and increases the minimum amount of line coverage to 85%.