### PR TITLE
add doctests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,11 +54,8 @@ jobs:
     - name: Install llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
 
-    - name: Install nextest
-      uses: taiki-e/install-action@nextest
-
     - name: Run Tests
-      run: cargo llvm-cov --cobertura --output-path cobertura.xml nextest
+      run: cargo +nightly llvm-cov --doctests --cobertura --output-path cobertura.xml
 
     - name: Generate Code Coverage Summary
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
       uses: taiki-e/install-action@cargo-llvm-cov
 
     - name: Run Tests
-      run: cargo +nightly llvm-cov --doctests --cobertura --output-path cobertura.xml
+      run: cargo +nightly llvm-cov --workspace --all-features --doctests --cobertura --output-path cobertura.xml
 
     - name: Generate Code Coverage Summary
       uses: irongut/CodeCoverageSummary@v1.3.0


### PR DESCRIPTION
I want to add doctests, these are only supported on nightly but I think it is fine for testing.
Nextest does not support doctests but for a GA it should be fine with the normal tests

https://github.com/taiki-e/cargo-llvm-cov

Also, tests have been modified to cover the entire workspace and all features