### PR TITLE
Let subscribers specify sub_id

### DIFF
--- a/kitchensink/benchmarking/README.md
+++ b/kitchensink/benchmarking/README.md
@@ -30,7 +30,7 @@ Execute benchmarks to generate new weights for a given pallet that is configured
 # run the pallet benchmarks
 frame-omni-bencher v1 benchmark pallet \
     --runtime ../../target/release/wbuild/idn-sdk-kitchensink-runtime/idn_sdk_kitchensink_runtime.compact.compressed.wasm \
-    --pallet pallet-idn-manager \
+    --pallet PALLET-NAME \
     --extrinsic "" \
     --template ../../kitchensink/benchmarking/weight-template.hbs \
     --output src/weights.rs

--- a/pallets/idn-manager/src/benchmarking.rs
+++ b/pallets/idn-manager/src/benchmarking.rs
@@ -51,10 +51,12 @@ mod benchmarks {
 			)
 			.unwrap(),
 		);
+		let sub_id = None;
+
 		T::Currency::set_balance(&subscriber, 1_000_000u32.into());
 
 		#[extrinsic_call]
-		_(origin, credits, target.clone(), call_index, frequency, metadata, pulse_filter);
+		_(origin, credits, target.clone(), call_index, frequency, metadata, pulse_filter, sub_id);
 
 		// assert that the subscription details are correct
 		let (_, sub) = Subscriptions::<T>::iter().next().unwrap();
@@ -78,6 +80,7 @@ mod benchmarks {
 		let frequency: BlockNumberFor<T> = 1u32.into();
 		let metadata = None;
 		let pulse_filter = None;
+		let sub_id = None;
 
 		T::Currency::set_balance(&subscriber, 1_000_000u32.into());
 
@@ -89,6 +92,7 @@ mod benchmarks {
 			frequency,
 			metadata,
 			pulse_filter,
+			sub_id,
 		);
 
 		// assert that the subscription state is correct
@@ -113,6 +117,7 @@ mod benchmarks {
 		let frequency: BlockNumberFor<T> = 1u32.into();
 		let metadata = None;
 		let pulse_filter = None;
+		let sub_id = None;
 
 		T::Currency::set_balance(&subscriber, 1_000_000u32.into());
 
@@ -124,6 +129,7 @@ mod benchmarks {
 			frequency,
 			metadata,
 			pulse_filter,
+			sub_id,
 		);
 
 		// assert that the subscription was created
@@ -147,6 +153,7 @@ mod benchmarks {
 		let frequency: BlockNumberFor<T> = 1u32.into();
 		let metadata = None;
 		let pulse_filter = None;
+		let sub_id = None;
 
 		T::Currency::set_balance(&subscriber, 1_000_000u32.into());
 
@@ -158,6 +165,7 @@ mod benchmarks {
 			frequency,
 			metadata,
 			pulse_filter,
+			sub_id,
 		);
 
 		// assert that the subscription state is correct
@@ -195,6 +203,7 @@ mod benchmarks {
 		let frequency: BlockNumberFor<T> = 1u32.into();
 		let metadata = None;
 		let pulse_filter = None;
+		let sub_id = None;
 
 		T::Currency::set_balance(&subscriber, 1_000_000u32.into());
 
@@ -206,6 +215,7 @@ mod benchmarks {
 			frequency,
 			metadata,
 			pulse_filter,
+			sub_id,
 		);
 
 		// assert that the subscription state is correct

--- a/pallets/idn-manager/src/benchmarking.rs
+++ b/pallets/idn-manager/src/benchmarking.rs
@@ -17,7 +17,7 @@
 //! Benchmarking setup for pallet-template
 
 use super::*;
-use crate::{pallet::Pallet as IdnManager, CreateSubParamsOf, PulsePropertyOf};
+use crate::{pallet::Pallet as IdnManager, CreateSubParamsOf, PulsePropertyOf, UpdateSubParamsOf};
 use frame_benchmarking::v2::*;
 use frame_support::{
 	traits::{fungible::Mutate, OriginTrait},
@@ -199,8 +199,15 @@ mod benchmarks {
 			.unwrap(),
 		);
 
+		let params = UpdateSubParamsOf::<T> {
+			sub_id,
+			credits: new_credits,
+			frequency: new_frequency,
+			pulse_filter: new_pulse_filter.clone(),
+		};
+
 		#[extrinsic_call]
-		_(origin, sub_id, new_credits, new_frequency, new_pulse_filter.clone());
+		_(origin, params);
 
 		// assert that the subscription state is correct
 		let sub = Subscriptions::<T>::get(sub_id).unwrap();

--- a/pallets/idn-manager/src/benchmarking.rs
+++ b/pallets/idn-manager/src/benchmarking.rs
@@ -17,7 +17,7 @@
 //! Benchmarking setup for pallet-template
 
 use super::*;
-use crate::{pallet::Pallet as IdnManager, PulsePropertyOf};
+use crate::{pallet::Pallet as IdnManager, CreateSubParamsOf, PulsePropertyOf};
 use frame_benchmarking::v2::*;
 use frame_support::{
 	traits::{fungible::Mutate, OriginTrait},
@@ -55,8 +55,18 @@ mod benchmarks {
 
 		T::Currency::set_balance(&subscriber, 1_000_000u32.into());
 
+		let params = CreateSubParamsOf::<T> {
+			credits,
+			target: target.clone(),
+			call_index,
+			frequency,
+			metadata,
+			pulse_filter,
+			sub_id,
+		};
+
 		#[extrinsic_call]
-		_(origin, credits, target.clone(), call_index, frequency, metadata, pulse_filter, sub_id);
+		_(origin, params);
 
 		// assert that the subscription details are correct
 		let (_, sub) = Subscriptions::<T>::iter().next().unwrap();
@@ -86,13 +96,15 @@ mod benchmarks {
 
 		let _ = IdnManager::<T>::create_subscription(
 			<T as frame_system::Config>::RuntimeOrigin::signed(subscriber.clone()),
-			credits,
-			target.clone(),
-			call_index,
-			frequency,
-			metadata,
-			pulse_filter,
-			sub_id,
+			CreateSubParamsOf::<T> {
+				credits,
+				target: target.clone(),
+				call_index,
+				frequency,
+				metadata,
+				pulse_filter,
+				sub_id,
+			},
 		);
 
 		// assert that the subscription state is correct
@@ -123,13 +135,15 @@ mod benchmarks {
 
 		let _ = IdnManager::<T>::create_subscription(
 			<T as frame_system::Config>::RuntimeOrigin::signed(subscriber.clone()),
-			credits,
-			target.clone(),
-			call_index,
-			frequency,
-			metadata,
-			pulse_filter,
-			sub_id,
+			CreateSubParamsOf::<T> {
+				credits,
+				target: target.clone(),
+				call_index,
+				frequency,
+				metadata,
+				pulse_filter,
+				sub_id,
+			},
 		);
 
 		// assert that the subscription was created
@@ -159,13 +173,15 @@ mod benchmarks {
 
 		let _ = IdnManager::<T>::create_subscription(
 			<T as frame_system::Config>::RuntimeOrigin::signed(subscriber.clone()),
-			credits,
-			target.clone(),
-			call_index,
-			frequency,
-			metadata,
-			pulse_filter,
-			sub_id,
+			CreateSubParamsOf::<T> {
+				credits,
+				target: target.clone(),
+				call_index,
+				frequency,
+				metadata,
+				pulse_filter,
+				sub_id,
+			},
 		);
 
 		// assert that the subscription state is correct
@@ -209,13 +225,15 @@ mod benchmarks {
 
 		let _ = IdnManager::<T>::create_subscription(
 			<T as frame_system::Config>::RuntimeOrigin::signed(subscriber.clone()),
-			credits,
-			target.clone(),
-			call_index,
-			frequency,
-			metadata,
-			pulse_filter,
-			sub_id,
+			CreateSubParamsOf::<T> {
+				credits,
+				target: target.clone(),
+				call_index,
+				frequency,
+				metadata,
+				pulse_filter,
+				sub_id,
+			},
 		);
 
 		// assert that the subscription state is correct

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -266,6 +266,24 @@ pub type CreateSubParamsOf<T> = CreateSubParams<
 	PulseFilterOf<T>,
 >;
 
+#[derive(Encode, Decode, Clone, TypeInfo, MaxEncodedLen, Debug, PartialEq)]
+pub struct UpdateSubParams<SubId, Credits, Frequency, PulseFilter> {
+	pub sub_id: SubscriptionId,
+	// New number of random values
+	pub credits: T::Credits,
+	// New distribution interval
+	pub frequency: BlockNumberFor<T>,
+	// New Pulse Filter
+	pub pulse_filter: Option<PulseFilterOf<T>>,
+}
+
+// pub sub_id: SubscriptionId,
+// // New number of random values
+// pub credits: T::Credits,
+// // New distribution interval
+// pub frequency: BlockNumberFor<T>,
+// // New Pulse Filter
+// pub pulse_filter: Option<PulseFilterOf<T>>,
 #[derive(Encode, Decode, Clone, PartialEq, TypeInfo, MaxEncodedLen, Debug)]
 pub enum SubscriptionState {
 	Active,
@@ -460,13 +478,7 @@ pub mod pallet {
 		pub fn update_subscription(
 			// Must match the subscription's original caller
 			origin: OriginFor<T>,
-			sub_id: SubscriptionId,
-			// New number of random values
-			credits: T::Credits,
-			// New distribution interval
-			frequency: BlockNumberFor<T>,
-			// New Pulse Filter
-			pulse_filter: Option<PulseFilterOf<T>>,
+			params: UpdateSubParamsOf<T>,
 		) -> DispatchResult {
 			let subscriber = ensure_signed(origin)?;
 

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -248,14 +248,22 @@ pub type SubscriptionDetailsOf<T> =
 
 pub type SubscriptionId = [u8; 32];
 
+/// Parameters for creating a new subscription
 #[derive(Encode, Decode, Clone, TypeInfo, MaxEncodedLen, Debug, PartialEq)]
 pub struct CreateSubParams<Credits, BlockNumber, Metadata, PulseFilter> {
+	// Number of random values to receive
 	pub credits: Credits,
+	// XCM multilocation for random value delivery
 	pub target: Location,
+	// Call index for XCM message
 	pub call_index: CallIndex,
+	// Distribution interval for random values
 	pub frequency: BlockNumber,
+	// Bounded vector for additional data
 	pub metadata: Option<Metadata>,
+	// Optional Pulse Filter
 	pub pulse_filter: Option<PulseFilter>,
+	// Optional Subscription Id, if None, a new one will be generated
 	pub sub_id: Option<SubscriptionId>,
 }
 
@@ -266,8 +274,10 @@ pub type CreateSubParamsOf<T> = CreateSubParams<
 	PulseFilterOf<T>,
 >;
 
+/// Parameters for updating an existing subscription
 #[derive(Encode, Decode, Clone, TypeInfo, MaxEncodedLen, Debug, PartialEq)]
 pub struct UpdateSubParams<SubId, Credits, Frequency, PulseFilter> {
+	// The Subscription Id
 	pub sub_id: SubId,
 	// New number of random values
 	pub credits: Credits,

--- a/pallets/idn-manager/src/tests/pallet.rs
+++ b/pallets/idn-manager/src/tests/pallet.rs
@@ -21,7 +21,7 @@ use crate::{
 	tests::mock::{self, Balances, ExtBuilder, Test, *},
 	traits::{BalanceDirection, DepositCalculator, DiffBalance, FeesManager},
 	Config, CreateSubParamsOf, Error, Event, HoldReason, PulseFilterOf, PulsePropertyOf,
-	SubscriptionState, Subscriptions,
+	SubscriptionState, Subscriptions, UpdateSubParamsOf,
 };
 use frame_support::{
 	assert_noop, assert_ok,
@@ -116,10 +116,12 @@ fn update_subscription(
 
 	assert_ok!(IdnManager::update_subscription(
 		RuntimeOrigin::signed(subscriber.clone()),
-		sub_id,
-		new_credits,
-		new_frequency,
-		None
+		UpdateSubParamsOf::<Test> {
+			sub_id,
+			credits: new_credits,
+			frequency: new_frequency,
+			pulse_filter: None
+		}
 	));
 
 	let new_fees = <Test as Config>::FeesManager::calculate_subscription_fees(&new_credits);
@@ -566,10 +568,12 @@ fn update_subscription_fails_if_sub_does_not_exists() {
 		assert_noop!(
 			IdnManager::update_subscription(
 				RuntimeOrigin::signed(ALICE),
-				sub_id,
-				new_credits,
-				new_frequency,
-				None
+				UpdateSubParamsOf::<Test> {
+					sub_id,
+					credits: new_credits,
+					frequency: new_frequency,
+					pulse_filter: None
+				}
 			),
 			Error::<Test>::SubscriptionDoesNotExist
 		);
@@ -606,17 +610,19 @@ fn update_subscription_fails_if_filtering_randomness() {
 		assert_noop!(
 			IdnManager::update_subscription(
 				RuntimeOrigin::signed(ALICE),
-				sub_id,
-				credits,
-				frequency,
-				Some(
-					BoundedVec::try_from(vec![
-						PulsePropertyOf::<Test>::Round(1),
-						PulsePropertyOf::<Test>::Rand([1u8; 32]),
-						PulsePropertyOf::<Test>::Sig([1u8; 64])
-					])
-					.unwrap()
-				)
+				UpdateSubParamsOf::<Test> {
+					sub_id,
+					credits,
+					frequency,
+					pulse_filter: Some(
+						BoundedVec::try_from(vec![
+							PulsePropertyOf::<Test>::Round(1),
+							PulsePropertyOf::<Test>::Rand([1u8; 32]),
+							PulsePropertyOf::<Test>::Sig([1u8; 64])
+						])
+						.unwrap()
+					)
+				}
 			),
 			Error::<Test>::FilterRandNotPermitted
 		);
@@ -1089,10 +1095,12 @@ fn operations_fail_if_origin_is_not_the_subscriber() {
 		assert_noop!(
 			IdnManager::update_subscription(
 				RuntimeOrigin::signed(BOB.clone()),
-				sub_id,
-				new_credits,
-				new_frequency,
-				None
+				UpdateSubParamsOf::<Test> {
+					sub_id,
+					credits: new_credits,
+					frequency: new_frequency,
+					pulse_filter: None
+				}
 			),
 			Error::<Test>::NotSubscriber
 		);

--- a/pallets/idn-manager/src/weights.rs
+++ b/pallets/idn-manager/src/weights.rs
@@ -61,63 +61,63 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn create_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `42`
-		//  Estimated: `10727`
-		// Minimum execution time: 90_000_000 picoseconds.
-		Weight::from_parts(93_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 94_000_000 picoseconds.
+		Weight::from_parts(95_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	fn pause_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `221`
-		//  Estimated: `10727`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn kill_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `279`
-		//  Estimated: `10727`
-		// Minimum execution time: 73_000_000 picoseconds.
-		Weight::from_parts(76_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 77_000_000 picoseconds.
+		Weight::from_parts(79_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn update_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `279`
-		//  Estimated: `10727`
-		// Minimum execution time: 74_000_000 picoseconds.
-		Weight::from_parts(78_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 77_000_000 picoseconds.
+		Weight::from_parts(78_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	fn reactivate_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `221`
-		//  Estimated: `10727`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(14_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -126,63 +126,63 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests.
 impl WeightInfo for () {
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn create_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `42`
-		//  Estimated: `10727`
-		// Minimum execution time: 90_000_000 picoseconds.
-		Weight::from_parts(93_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 94_000_000 picoseconds.
+		Weight::from_parts(95_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	fn pause_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `221`
-		//  Estimated: `10727`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn kill_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `279`
-		//  Estimated: `10727`
-		// Minimum execution time: 73_000_000 picoseconds.
-		Weight::from_parts(76_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 77_000_000 picoseconds.
+		Weight::from_parts(79_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn update_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `279`
-		//  Estimated: `10727`
-		// Minimum execution time: 74_000_000 picoseconds.
-		Weight::from_parts(78_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 77_000_000 picoseconds.
+		Weight::from_parts(78_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5662), added: 8137, mode: `MaxEncodedLen`)
 	fn reactivate_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `221`
-		//  Estimated: `10727`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(14_000_000, 10727)
+		//  Estimated: `9127`
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}

--- a/pallets/idn-manager/src/weights.rs
+++ b/pallets/idn-manager/src/weights.rs
@@ -60,64 +60,64 @@ pub trait WeightInfo {
 /// Weights for `pallet_idn_manager` using the IDN SDK Kitchensink Runtime and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
-	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
 	fn create_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `42`
-		//  Estimated: `9095`
-		// Minimum execution time: 92_000_000 picoseconds.
-		Weight::from_parts(94_000_000, 9095)
+		//  Estimated: `10727`
+		// Minimum execution time: 90_000_000 picoseconds.
+		Weight::from_parts(93_000_000, 10727)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	fn pause_subscription() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `189`
-		//  Estimated: `9095`
-		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 9095)
+		//  Measured:  `221`
+		//  Estimated: `10727`
+		// Minimum execution time: 13_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 10727)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn kill_subscription() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `247`
-		//  Estimated: `9095`
-		// Minimum execution time: 77_000_000 picoseconds.
-		Weight::from_parts(79_000_000, 9095)
+		//  Measured:  `279`
+		//  Estimated: `10727`
+		// Minimum execution time: 73_000_000 picoseconds.
+		Weight::from_parts(76_000_000, 10727)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn update_subscription() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `247`
-		//  Estimated: `9095`
-		// Minimum execution time: 77_000_000 picoseconds.
-		Weight::from_parts(78_000_000, 9095)
+		//  Measured:  `279`
+		//  Estimated: `10727`
+		// Minimum execution time: 74_000_000 picoseconds.
+		Weight::from_parts(78_000_000, 10727)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	fn reactivate_subscription() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `189`
-		//  Estimated: `9095`
-		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 9095)
+		//  Measured:  `221`
+		//  Estimated: `10727`
+		// Minimum execution time: 13_000_000 picoseconds.
+		Weight::from_parts(14_000_000, 10727)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -125,64 +125,64 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests.
 impl WeightInfo for () {
+	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
-	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
 	fn create_subscription() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `42`
-		//  Estimated: `9095`
-		// Minimum execution time: 92_000_000 picoseconds.
-		Weight::from_parts(94_000_000, 9095)
+		//  Estimated: `10727`
+		// Minimum execution time: 90_000_000 picoseconds.
+		Weight::from_parts(93_000_000, 10727)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	fn pause_subscription() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `189`
-		//  Estimated: `9095`
-		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 9095)
+		//  Measured:  `221`
+		//  Estimated: `10727`
+		// Minimum execution time: 13_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 10727)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn kill_subscription() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `247`
-		//  Estimated: `9095`
-		// Minimum execution time: 77_000_000 picoseconds.
-		Weight::from_parts(79_000_000, 9095)
+		//  Measured:  `279`
+		//  Estimated: `10727`
+		// Minimum execution time: 73_000_000 picoseconds.
+		Weight::from_parts(76_000_000, 10727)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:1 w:1)
 	/// Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(69), added: 2544, mode: `MaxEncodedLen`)
 	fn update_subscription() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `247`
-		//  Estimated: `9095`
-		// Minimum execution time: 77_000_000 picoseconds.
-		Weight::from_parts(78_000_000, 9095)
+		//  Measured:  `279`
+		//  Estimated: `10727`
+		// Minimum execution time: 74_000_000 picoseconds.
+		Weight::from_parts(78_000_000, 10727)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `IdnManager::Subscriptions` (r:1 w:1)
-	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(5630), added: 8105, mode: `MaxEncodedLen`)
+	/// Proof: `IdnManager::Subscriptions` (`max_values`: None, `max_size`: Some(7262), added: 9737, mode: `MaxEncodedLen`)
 	fn reactivate_subscription() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `189`
-		//  Estimated: `9095`
-		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 9095)
+		//  Measured:  `221`
+		//  Estimated: `10727`
+		// Minimum execution time: 13_000_000 picoseconds.
+		Weight::from_parts(14_000_000, 10727)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}


### PR DESCRIPTION
close #151 

This PR allow subscribers to pass an optional subscription id, when specified the pallet will try to create a subscription with that id. If it already existed it will error out