### PR TITLE
Feat/charge idle subs

### DIFF
--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -68,8 +68,8 @@ where
 	/// Calculate the subscription fees based on the number of requested credits.
 	///
 	/// This function implements a tiered pricing model with volume discounts:
-	/// - Tier 1 (1-10 credits): 100% of base fee per credit (no discount)
-	/// - Tier 2 (11-100 credits): 95% of base fee per credit (5% discount)
+	/// - Tier 1 (1-10_000 credits): 100% of base fee per credit (no discount)
+	/// - Tier 2 (10_001-100_000 credits): 95% of base fee per credit (5% discount)
 	/// - Tier 3 (101-1000 credits): 90% of base fee per credit (10% discount)
 	/// - Tier 4 (1001-10000 credits): 80% of base fee per credit (20% discount)
 	/// - Tier 5 (10001+ credits): 70% of base fee per credit (30% discount)
@@ -88,21 +88,21 @@ where
 	///
 	/// # Example
 	/// ```nocompile
-	/// // 100 credits would incur a fee of:
-	/// // - 10 credits at full price: 10 * 100 = 1000
-	/// // - 90 credits at 5% discount: 90 * 95 = 8550
-	/// // Total: 9550
+	/// // 100_000 credits would incur a fee of:
+	/// // - 10_000 credits at full price: 10_000 * 100 = 1_000_000
+	/// // - 90_000 credits at 5% discount: 90_000 * 95 = 8_550_000
+	/// // Total: 9_550_000
 	/// let fees = calculate_subscription_fees(&100u64);
-	/// assert_eq!(fees, 9550u64.into());
+	/// assert_eq!(fees, 9_550_000u64.into());
 	/// ```
 	fn calculate_subscription_fees(credits: &u64) -> Balances::Balance {
 		// Define tier boundaries and their respective discount rates (in basis points)
 		const TIERS: [(u64, u64); 5] = [
-			(1, 0),        // 0-10: 0% discount
-			(11, 500),     // 11-100: 5% discount
-			(101, 1000),   // 101-1000: 10% discount
-			(1001, 2000),  // 1001-10000: 20% discount
-			(10001, 3000), // 10001+: 30% discount
+			(1, 0),           // 0-10_000: 0% discount
+			(10_001, 5),      // 10_001-10_000: 5% discount
+			(100_001, 10),    // 100_001-1000_000: 10% discount
+			(1_000_001, 20),  // 1_000_001-10_000_000: 20% discount
+			(10_000_001, 30), // 10_000_001+: 30% discount
 		];
 
 		const BASE_FEE: u64 = 100;
@@ -124,8 +124,8 @@ where
 
 			let tier_fee = BASE_FEE
 				.saturating_mul(credits_in_tier)
-				.saturating_mul(10_000 - current_tier_discount)
-				.saturating_div(10_000);
+				.saturating_mul(100 - current_tier_discount)
+				.saturating_div(100);
 
 			total_fee = total_fee.saturating_add(tier_fee);
 			remaining_credits = remaining_credits.saturating_sub(credits_in_tier);
@@ -161,20 +161,20 @@ where
 	/// # Examples
 	/// ```nocompile
 	/// // When increasing credits, additional fees are collected:
-	/// // Old: 10 credits (1000 fee), New: 50 credits (5000 fee)
-	/// let diff = calculate_diff_fees(&10, &50);
-	/// assert_eq!(diff.balance, 4000);
+	/// // Old: 10_000 credits (1_000 fee), New: 50_000 credits (5_000_000 fee)
+	/// let diff = calculate_diff_fees(&10_000, &50_000);
+	/// assert_eq!(diff.balance, 4_000_000);
 	/// assert_eq!(diff.direction, BalanceDirection::Collect);
 	///
 	/// // When decreasing credits, excess fees are released:
-	/// // Old: 100 credits (9550 fee), New: 10 credits (1000 fee)
-	/// let diff = calculate_diff_fees(&100, &10);
-	/// assert_eq!(diff.balance, 8550);
+	/// // Old: 100_000 credits (9_550_000 fee), New: 10_000 credits (1_000_000 fee)
+	/// let diff = calculate_diff_fees(&100_000, &10_000);
+	/// assert_eq!(diff.balance, 8_550_000);
 	/// assert_eq!(diff.direction, BalanceDirection::Release);
 	///
 	/// // When credits remain the same, no fee changes occur:
-	/// // Old: 50 credits (5000 fee), New: 50 credits (5000 fee)
-	/// let diff = calculate_diff_fees(&50, &50);
+	/// // Old: 50_000 credits (5_000_000 fee), New: 50_000 credits (5_000_000 fee)
+	/// let diff = calculate_diff_fees(&50_000, &50_000);
 	/// assert_eq!(diff.balance, 0);
 	/// assert_eq!(diff.direction, BalanceDirection::None);
 	/// ```
@@ -222,7 +222,7 @@ where
 	///
 	/// # Example
 	/// ```nocompile
-	/// let fees = 1000u64.into();
+	/// let fees = 1_000_000u64.into();
 	/// let result = FeesManagerImpl::<Treasury, BaseFee, Subscription, Balances>::collect_fees(
 	///     &fees,
 	///     &subscription
@@ -258,6 +258,28 @@ where
 		}
 
 		Ok(collected)
+	}
+
+	/// Get the number of credits consumed by a subscription when this one gets a pulse in a block.
+	///
+	/// # Parameters
+	/// * `_sub` - The subscription object
+	///
+	/// # Returns
+	/// The number of credits consumed
+	fn get_consume_credits(_sub: &S) -> u64 {
+		1000
+	}
+
+	/// Get the number of credits consumed by a subscription when this one is idle in a block.
+	///
+	/// # Parameters
+	/// * `_sub` - The subscription object
+	///
+	/// # Returns
+	/// The number of idle credits
+	fn get_idle_credits(_sub: &S) -> u64 {
+		10
 	}
 }
 
@@ -297,7 +319,7 @@ impl<
 	///
 	/// // If SDMultiplier is 2 and the subscription encodes to 100 bytes:
 	/// let deposit = DepositCalculatorImpl::<SDMultiplier, u64>::calculate_storage_deposit(&subscription);
-	/// assert_eq!(deposit, 200);
+	/// assert_eq!(deposit, 200_000);
 	/// ```
 	fn calculate_storage_deposit(sub: &S) -> Deposit {
 		// [SRLabs] Note: There is a theoretical edge case where if the `Deposit` type (e.g., u64)
@@ -338,20 +360,20 @@ impl<
 	/// let new_sub = /* same subscription with 150 bytes encoded size */;
 	///
 	/// // If SDMultiplier is 2:
-	/// // Old deposit = 2 * 100 = 200
-	/// // New deposit = 2 * 150 = 300
+	/// // Old deposit = 2 * 100_000 = 200_000
+	/// // New deposit = 2 * 150_000 = 300_000
 	/// let diff = DepositCalculatorImpl::<SDMultiplier, u64>::calculate_diff_deposit(&old_sub, &new_sub);
-	/// assert_eq!(diff.balance, 100); // 300 - 200 = 100 more needed
+	/// assert_eq!(diff.balance, 100_000); // 300_000 - 200_000 = 100_000 more needed
 	/// assert_eq!(diff.direction, BalanceDirection::Collect);
 	///
 	/// // When subscription size decreases (e.g., metadata removed):
 	/// let old_sub = /* subscription with 150 bytes encoded size */;
-	/// let new_sub = /* same subscription with 100 bytes encoded size */;
+	/// let new_sub = /* same subscription with 100_000 bytes encoded size */;
 	///
-	/// // Old deposit = 2 * 150 = 300
-	/// // New deposit = 2 * 100 = 200
+	/// // Old deposit = 2 * 150_000 = 300_000
+	/// // New deposit = 2 * 100_000 = 200_000
 	/// let diff = DepositCalculatorImpl::<SDMultiplier, u64>::calculate_diff_deposit(&old_sub, &new_sub);
-	/// assert_eq!(diff.balance, 100); // 300 - 200 = 100 to release
+	/// assert_eq!(diff.balance, 100_000); // 300_000 - 200_000 = 100_000 to release
 	/// assert_eq!(diff.direction, BalanceDirection::Release);
 	/// ```
 	fn calculate_diff_deposit(old_sub: &S, new_sub: &S) -> DiffBalance<Deposit> {

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -98,9 +98,9 @@ where
 	fn calculate_subscription_fees(credits: &u64) -> Balances::Balance {
 		// Define tier boundaries and their respective discount rates (in basis points)
 		const TIERS: [(u64, u64); 5] = [
-			(1, 0),           // 0-10_000: 0% discount
-			(10_001, 5),      // 10_001-10_000: 5% discount
-			(100_001, 10),    // 100_001-1000_000: 10% discount
+			(1, 0),           // 1-10_000: 0% discount
+			(10_001, 5),      // 10_001-100_000: 5% discount
+			(100_001, 10),    // 100_001-1_000_000: 10% discount
 			(1_000_001, 20),  // 1_000_001-10_000_000: 20% discount
 			(10_000_001, 30), // 10_000_001+: 30% discount
 		];

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -94,7 +94,6 @@ use frame_support::{
 	pallet_prelude::{
 		ensure, Blake2_128Concat, DispatchError, DispatchResult, DispatchResultWithPostInfo, Hooks,
 		IsType, OptionQuery, StorageMap, StorageValue, ValueQuery, Zero,
-		IsType, OptionQuery, StorageMap, Zero,
 	},
 	sp_runtime::traits::AccountIdConversion,
 	traits::{

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -94,6 +94,7 @@ use frame_support::{
 	pallet_prelude::{
 		ensure, Blake2_128Concat, DispatchError, DispatchResult, DispatchResultWithPostInfo, Hooks,
 		IsType, OptionQuery, StorageMap, StorageValue, ValueQuery, Zero,
+		IsType, OptionQuery, StorageMap, Zero,
 	},
 	sp_runtime::traits::AccountIdConversion,
 	traits::{
@@ -578,6 +579,7 @@ pub mod pallet {
 				Self::manage_diff_fees(&subscriber, &fees_diff)?;
 				// Hold or refund diff deposit
 				Self::manage_diff_deposit(&subscriber, &deposit_diff)?;
+
 				Self::deposit_event(Event::SubscriptionUpdated { sub_id: params.sub_id });
 				Ok::<(), DispatchError>(())
 			})?;

--- a/pallets/idn-manager/src/tests/fee_examples.rs
+++ b/pallets/idn-manager/src/tests/fee_examples.rs
@@ -54,6 +54,12 @@ impl FeesManager<u32, u32, (), (), ()> for LinearFeeCalculator {
 		// In this case, we don't need to do anything with the fees, so we just return them
 		Ok(*fees)
 	}
+	fn get_consume_credits(_sub: &()) -> u32 {
+		1000
+	}
+	fn get_idle_credits(_sub: &()) -> u32 {
+		10
+	}
 }
 
 /// Tiered fee calculator with predefined discount tiers
@@ -116,6 +122,12 @@ impl FeesManager<u32, u32, (), (), ()> for SteppedTieredFeeCalculator {
 	fn collect_fees(fees: &u32, _: &()) -> Result<u32, crate::traits::FeesError<u32, ()>> {
 		// In this case, we don't need to do anything with the fees, so we just return them
 		Ok(*fees)
+	}
+	fn get_consume_credits(_sub: &()) -> u32 {
+		1000
+	}
+	fn get_idle_credits(_sub: &()) -> u32 {
+		10
 	}
 }
 

--- a/pallets/idn-manager/src/traits.rs
+++ b/pallets/idn-manager/src/traits.rs
@@ -45,17 +45,21 @@ pub struct DiffBalance<Balance> {
 
 /// Trait for fees managing
 pub trait FeesManager<Fees, Credits, Sub: Subscription<S>, Err, S> {
-	/// Calculate the fees for a subscription based on the credits of random values required.
+	/// Calculate the fees for a subscription based on the credits of pulses required.
 	fn calculate_subscription_fees(credits: &Credits) -> Fees;
 	/// Calculate how much fees should be held or release when a subscription changes.
 	///
-	/// * `old_credits` - the credits of random values required before the change.
-	/// * `new_credits` - the credits of random values required after the change, this will
-	///   represent the updated credits in an update operation. Or the credits actually consumed in
-	///   a kill operation.
+	/// * `old_credits` - the credits of pulses required before the change.
+	/// * `new_credits` - the credits of pulses required after the change, this will represent the
+	///   updated credits in an update operation. Or the credits actually consumed in a kill
+	///   operation.
 	fn calculate_diff_fees(old_credits: &Credits, new_credits: &Credits) -> DiffBalance<Fees>;
 	/// Distributes collected fees. Returns the fees that were effectively collected.
 	fn collect_fees(fees: &Fees, sub: &Sub) -> Result<Fees, FeesError<Fees, Err>>;
+	/// Returns how many credits this subscription pays for receiving a pulse
+	fn get_consume_credits(sub: &Sub) -> Credits;
+	/// Returns how many credits this subscription pays for skipping to receive a pulse
+	fn get_idle_credits(sub: &Sub) -> Credits;
 }
 
 pub trait Subscription<Subscriber> {

--- a/pallets/idn-manager/src/weights.rs
+++ b/pallets/idn-manager/src/weights.rs
@@ -71,10 +71,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `42`
 		//  Estimated: `9127`
-		// Minimum execution time: 85_000_000 picoseconds.
-		Weight::from_parts(89_870_340, 9127)
-			// Standard Error: 2_365
-			.saturating_add(Weight::from_parts(57_545, 0).saturating_mul(l.into()))
+		// Minimum execution time: 83_000_000 picoseconds.
+		Weight::from_parts(87_786_358, 9127)
+			// Standard Error: 1_980
+			.saturating_add(Weight::from_parts(24_710, 0).saturating_mul(l.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -85,7 +85,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Measured:  `244`
 		//  Estimated: `9127`
 		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 10727)
+		Weight::from_parts(15_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -100,7 +100,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Measured:  `302`
 		//  Estimated: `9127`
 		// Minimum execution time: 74_000_000 picoseconds.
-		Weight::from_parts(80_000_000, 9127)
+		Weight::from_parts(76_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -114,9 +114,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Measured:  `302`
 		//  Estimated: `9127`
 		// Minimum execution time: 54_000_000 picoseconds.
-		Weight::from_parts(71_724_420, 9127)
-			// Standard Error: 3_803
-			.saturating_add(Weight::from_parts(88_642, 0).saturating_mul(l.into()))
+		Weight::from_parts(68_525_194, 9127)
+			// Standard Error: 3_659
+			.saturating_add(Weight::from_parts(83_134, 0).saturating_mul(l.into()))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `244`
 		//  Estimated: `9127`
-		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(16_000_000, 9127)
+		// Minimum execution time: 13_000_000 picoseconds.
+		Weight::from_parts(14_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -146,10 +146,10 @@ impl WeightInfo for () {
 		// Proof Size summary in bytes:
 		//  Measured:  `42`
 		//  Estimated: `9127`
-		// Minimum execution time: 85_000_000 picoseconds.
-		Weight::from_parts(89_870_340, 9127)
-			// Standard Error: 2_365
-			.saturating_add(Weight::from_parts(57_545, 0).saturating_mul(l.into()))
+		// Minimum execution time: 83_000_000 picoseconds.
+		Weight::from_parts(87_786_358, 9127)
+			// Standard Error: 1_980
+			.saturating_add(Weight::from_parts(24_710, 0).saturating_mul(l.into()))
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
@@ -160,7 +160,7 @@ impl WeightInfo for () {
 		//  Measured:  `244`
 		//  Estimated: `9127`
 		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 10727)
+		Weight::from_parts(15_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
@@ -175,7 +175,7 @@ impl WeightInfo for () {
 		//  Measured:  `302`
 		//  Estimated: `9127`
 		// Minimum execution time: 74_000_000 picoseconds.
-		Weight::from_parts(80_000_000, 9127)
+		Weight::from_parts(76_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
@@ -189,9 +189,9 @@ impl WeightInfo for () {
 		//  Measured:  `302`
 		//  Estimated: `9127`
 		// Minimum execution time: 54_000_000 picoseconds.
-		Weight::from_parts(71_724_420, 9127)
-			// Standard Error: 3_803
-			.saturating_add(Weight::from_parts(88_642, 0).saturating_mul(l.into()))
+		Weight::from_parts(68_525_194, 9127)
+			// Standard Error: 3_659
+			.saturating_add(Weight::from_parts(83_134, 0).saturating_mul(l.into()))
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
@@ -201,8 +201,8 @@ impl WeightInfo for () {
 		// Proof Size summary in bytes:
 		//  Measured:  `244`
 		//  Estimated: `9127`
-		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(16_000_000, 9127)
+		// Minimum execution time: 13_000_000 picoseconds.
+		Weight::from_parts(14_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}

--- a/pallets/idn-manager/src/weights.rs
+++ b/pallets/idn-manager/src/weights.rs
@@ -72,9 +72,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Measured:  `42`
 		//  Estimated: `9127`
 		// Minimum execution time: 83_000_000 picoseconds.
-		Weight::from_parts(87_786_358, 9127)
-			// Standard Error: 1_980
-			.saturating_add(Weight::from_parts(24_710, 0).saturating_mul(l.into()))
+		Weight::from_parts(85_990_889, 9127)
+			// Standard Error: 1_336
+			.saturating_add(Weight::from_parts(57_696, 0).saturating_mul(l.into()))
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -85,7 +85,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Measured:  `244`
 		//  Estimated: `9127`
 		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 9127)
+		Weight::from_parts(14_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -99,8 +99,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `302`
 		//  Estimated: `9127`
-		// Minimum execution time: 74_000_000 picoseconds.
-		Weight::from_parts(76_000_000, 9127)
+		// Minimum execution time: 75_000_000 picoseconds.
+		Weight::from_parts(77_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -113,10 +113,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `302`
 		//  Estimated: `9127`
-		// Minimum execution time: 54_000_000 picoseconds.
-		Weight::from_parts(68_525_194, 9127)
-			// Standard Error: 3_659
-			.saturating_add(Weight::from_parts(83_134, 0).saturating_mul(l.into()))
+		// Minimum execution time: 53_000_000 picoseconds.
+		Weight::from_parts(68_316_388, 9127)
+			// Standard Error: 3_357
+			.saturating_add(Weight::from_parts(82_746, 0).saturating_mul(l.into()))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `244`
 		//  Estimated: `9127`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(14_000_000, 9127)
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 9127)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -147,9 +147,9 @@ impl WeightInfo for () {
 		//  Measured:  `42`
 		//  Estimated: `9127`
 		// Minimum execution time: 83_000_000 picoseconds.
-		Weight::from_parts(87_786_358, 9127)
-			// Standard Error: 1_980
-			.saturating_add(Weight::from_parts(24_710, 0).saturating_mul(l.into()))
+		Weight::from_parts(85_990_889, 9127)
+			// Standard Error: 1_336
+			.saturating_add(Weight::from_parts(57_696, 0).saturating_mul(l.into()))
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
@@ -160,7 +160,7 @@ impl WeightInfo for () {
 		//  Measured:  `244`
 		//  Estimated: `9127`
 		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 9127)
+		Weight::from_parts(14_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
@@ -174,8 +174,8 @@ impl WeightInfo for () {
 		// Proof Size summary in bytes:
 		//  Measured:  `302`
 		//  Estimated: `9127`
-		// Minimum execution time: 74_000_000 picoseconds.
-		Weight::from_parts(76_000_000, 9127)
+		// Minimum execution time: 75_000_000 picoseconds.
+		Weight::from_parts(77_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
@@ -188,10 +188,10 @@ impl WeightInfo for () {
 		// Proof Size summary in bytes:
 		//  Measured:  `302`
 		//  Estimated: `9127`
-		// Minimum execution time: 54_000_000 picoseconds.
-		Weight::from_parts(68_525_194, 9127)
-			// Standard Error: 3_659
-			.saturating_add(Weight::from_parts(83_134, 0).saturating_mul(l.into()))
+		// Minimum execution time: 53_000_000 picoseconds.
+		Weight::from_parts(68_316_388, 9127)
+			// Standard Error: 3_357
+			.saturating_add(Weight::from_parts(82_746, 0).saturating_mul(l.into()))
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
@@ -201,8 +201,8 @@ impl WeightInfo for () {
 		// Proof Size summary in bytes:
 		//  Measured:  `244`
 		//  Estimated: `9127`
-		// Minimum execution time: 13_000_000 picoseconds.
-		Weight::from_parts(14_000_000, 9127)
+		// Minimum execution time: 14_000_000 picoseconds.
+		Weight::from_parts(15_000_000, 9127)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}

--- a/pallets/idn-manager/src/weights.rs
+++ b/pallets/idn-manager/src/weights.rs
@@ -85,7 +85,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Measured:  `244`
 		//  Estimated: `9127`
 		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 9127)
+		Weight::from_parts(15_000_000, 10727)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -160,7 +160,7 @@ impl WeightInfo for () {
 		//  Measured:  `244`
 		//  Estimated: `9127`
 		// Minimum execution time: 14_000_000 picoseconds.
-		Weight::from_parts(15_000_000, 9127)
+		Weight::from_parts(15_000_000, 10727)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}


### PR DESCRIPTION
closes #160 

# Feat/charge idle subs

This pull request introduces the functionality to charge idle subscriptions in the IDN Manager pallet. The key changes are as follows:

## TL;DR

- Introduces the functionality to charge idle subscriptions.
- Updates the fee calculation logic to include idle credits.
- Enhances the subscription management to handle idle and active states.
- Updates weights and test cases to reflect the new functionality.

## Description

### New Features and Enhancements

1. **Charging Idle Subscriptions**:
   - Added functionality to charge subscriptions that are idle.
   - Introduced `get_idle_credits` and `get_consume_credits` methods to the `FeesManager` trait.
   - Updated the `distribute` method to handle idle subscriptions.

2. **Fee Calculation Updates**:
   - Modified the fee calculation logic to include idle credits.
   - Updated the tier boundaries and discount rates in the `calculate_subscription_fees` function.
   - Adjusted the `calculate_diff_fees` method to account for idle and active credits.

3. **Subscription Management Enhancements**:
   - Enhanced the subscription management to handle both idle and active states.
   - Updated the `collect_fees` method to collect fees based on the subscription's state.
   - Implemented logic to consume credits differently based on whether the subscription is idle or active.