### PR TITLE
Docs/idn manager pallet

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,9 @@ jobs:
     - name: Run cargo clippy
       run: cargo clippy --all-features -- -D warnings
 
+    - name: Run cargo doc
+      run: cargo doc --no-deps --all-features
+
     - name: Build
       run: cargo build --all-features --verbose
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8017,6 +8017,7 @@ dependencies = [
 name = "pallet-idn-manager"
 version = "0.0.1-dev"
 dependencies = [
+ "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8025,6 +8025,7 @@ dependencies = [
  "pallet-xcm",
  "parity-scale-codec",
  "scale-info",
+ "simple-mermaid",
  "sp-api",
  "sp-arithmetic",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ clap = { version = "4.5.13" }
 docify = { version = "0.2.9" }
 jsonrpsee = { version = "0.24.3" }
 log = { version = "=0.4.26", default-features = false }
+simple-mermaid = { version = "0.1.1" }
 
 # Parity SCALE Codec
 codec = { package = "parity-scale-codec", version = "=3.7.4", default-features = false, features = ["derive"] }

--- a/client/consensus/randomness-beacon/src/gossipsub.rs
+++ b/client/consensus/randomness-beacon/src/gossipsub.rs
@@ -23,7 +23,7 @@
 //! ## Overview
 //!
 //! - runs a libp2p node and handles peer connections
-//! - subscribes to a gossipsub topic and writes well-formed messages to a [`SharedState`]
+//! - subscribes to a gossipsub topic and writes well-formed messages to a `SharedState`
 //!
 //! ## Examples
 //!

--- a/pallets/idn-manager/Cargo.toml
+++ b/pallets/idn-manager/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec.workspace = true
+docify.workspace = true
 scale-info.workspace = true
 simple-mermaid.workspace = true
 sp-arithmetic.workspace = true

--- a/pallets/idn-manager/Cargo.toml
+++ b/pallets/idn-manager/Cargo.toml
@@ -15,6 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec.workspace = true
 scale-info.workspace = true
+simple-mermaid.workspace = true
 sp-arithmetic.workspace = true
 sp-api.workspace = true
 sp-core.workspace = true

--- a/pallets/idn-manager/README.md
+++ b/pallets/idn-manager/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The IDN Manager pallet provides functionality for managing subscriptions to a decentralized randomness service. It allows users to create, update, pause, and terminate subscriptions, as well as configure fees and storage deposits. This pallet is designed to be modular and extensible, allowing for different implementations of key components such as the fees manager and deposit calculator.
+The IDN Manager pallet provides functionality for managing subscriptions to randomness pulses. It allows users to create, update, pause, and terminate subscriptions, as well as configure fees and storage deposits. This pallet is designed to be modular and extensible, allowing for different implementations of key components such as the fees manager and deposit calculator.
 
 ## Key Features
 

--- a/pallets/idn-manager/README.md
+++ b/pallets/idn-manager/README.md
@@ -31,10 +31,6 @@ The subscription state lifecycle defines the different states a subscription can
 *   **Active:** The subscription is active and randomness is being distributed.
 *   **Paused:** The subscription is temporarily paused and randomness distribution is suspended.
 
-### Pulse Filtering Security
-
-To prevent malicious actors from manipulating the randomness distribution, filtering on `rand` values is explicitly prohibited. This ensures that subscribers cannot predict or influence the randomness they receive.
-
 ## Configuration
 
 The IDN Manager pallet can be configured using the following runtime parameters:

--- a/pallets/idn-manager/README.md
+++ b/pallets/idn-manager/README.md
@@ -1,3 +1,101 @@
 # IDN Manager Pallet
 
+## Overview
 
+The IDN Manager pallet provides functionality for managing subscriptions to a decentralized randomness service. It allows users to create, update, pause, and terminate subscriptions, as well as configure fees and storage deposits. This pallet is designed to be modular and extensible, allowing for different implementations of key components such as the fees manager and deposit calculator.
+
+## Key Features
+
+*   **Subscription Management:** Create, update, pause, and terminate subscriptions.
+*   **Fees Management:** Configurable fees for subscriptions, with tiered pricing and volume discounts.
+*   **Storage Deposits:** Ensures that sufficient funds are reserved to cover the cost of storing subscription data.
+*   **Pulse Filtering:** Allows subscribers to filter the randomness pulses they receive based on specific criteria.
+*   **XCM Integration:** Enables the delivery of randomness to other chains via Cross-Consensus Messaging (XCM).
+*   **Benchmarking:** Includes comprehensive benchmarking to measure and optimize performance.
+
+## Architecture
+
+The IDN Manager pallet is designed with a modular architecture, allowing for different implementations of key components. The main components include:
+
+*   **Subscriptions:** Stores information about active subscriptions, including the subscriber, target location, credits, and pulse filter.
+*   **Fees Manager:** Calculates and collects fees for subscriptions. Different implementations can be used to support various pricing models.
+*   **Deposit Calculator:** Calculates the storage deposits required for subscriptions.
+*   **Pulse Dispatcher:** Distributes randomness pulses to eligible subscriptions.
+
+## Concepts
+
+### Subscription State Lifecycle
+
+The subscription state lifecycle defines the different states a subscription can be in and the transitions between them. The possible states are:
+
+*   **Active:** The subscription is active and randomness is being distributed.
+*   **Paused:** The subscription is temporarily paused and randomness distribution is suspended.
+
+### Pulse Filtering Security
+
+To prevent malicious actors from manipulating the randomness distribution, filtering on `rand` values is explicitly prohibited. This ensures that subscribers cannot predict or influence the randomness they receive.
+
+## Configuration
+
+The IDN Manager pallet can be configured using the following runtime parameters:
+
+*   `SubMetadataLen`: The maximum length of the subscription metadata.
+*   `PulseFilterLen`: The maximum length of the pulse filter.
+*   `Credits`: The type used to represent the number of credits in a subscription.
+*   `MaxSubscriptions`: The maximum number of subscriptions allowed.
+*   `Currency`: The currency used for fees and deposits.
+*   `FeesManager`: The implementation used for managing fees.
+*   `DepositCalculator`: The implementation used for calculating storage deposits.
+*   `Pulse`: The type that represents a randomness pulse.
+
+## Usage
+
+### Creating a Subscription
+
+To create a subscription, call the `create_subscription` dispatchable with the desired parameters. 
+
+### Updating a Subscription
+
+To update a subscription, call the `update_subscription` dispatchable with the desired parameters.
+
+### Pausing a Subscription
+
+To pause a subscription, call the `pause_subscription` dispatchable with the subscription ID.
+
+### Reactivating a Subscription
+
+To reactivate a paused subscription, call the `reactivate_subscription` dispatchable with the subscription ID.
+
+### Terminating a Subscription
+
+To terminate a subscription, call the `kill_subscription` dispatchable with the subscription ID.
+
+## Events
+
+The IDN Manager pallet emits the following events:
+
+*   `SubscriptionCreated`: A new subscription has been created.
+*   `SubscriptionUpdated`: A subscription has been updated.
+*   `SubscriptionPaused`: A subscription has been paused.
+*   `SubscriptionReactivated`: A subscription has been reactivated.
+*   `SubscriptionRemoved`: A subscription has been terminated.
+*   `FeesCollected`: Fees have been successfully collected from a subscription.
+
+## Benchmarking
+
+The IDN Manager pallet includes comprehensive benchmarking to measure and optimize performance. The benchmarks cover the following operations:
+
+*   `create_subscription`
+*   `update_subscription`
+*   `pause_subscription`
+*   `reactivate_subscription`
+*   `kill_subscription`
+
+## Security Considerations
+
+*   **Pulse Filtering:** Filtering on `rand` values is explicitly prohibited to prevent malicious actors from manipulating the randomness distribution.
+*   **Fees and Deposits:** Proper configuration of fees and deposits is essential to ensure the economic sustainability of the randomness service.
+
+## License
+
+[Apache 2.0](../../LICENSE)

--- a/pallets/idn-manager/docs/mermaid/sub_state_lifecycle.mmd
+++ b/pallets/idn-manager/docs/mermaid/sub_state_lifecycle.mmd
@@ -1,0 +1,6 @@
+stateDiagram-v2
+    [*] --> Active
+    Active --> Paused
+    Paused --> Active
+    Paused --> [*]
+    Active --> [*]

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -14,7 +14,20 @@
  * limitations under the License.
  */
 
-//! # Implementations of public traits
+//! # Trait Implementations for the IDN Manager Pallet
+//!
+//! This file contains implementations of various traits required by the IDN Manager pallet.
+//! These implementations provide the concrete logic for calculating fees, managing deposits,
+//! and interacting with other pallets in the system.
+//!
+//! ## Key Implementations:
+//!
+//! - `SubscriptionTrait`: Implemented for the `Subscription` struct, providing access to
+//!   subscription details such as the subscriber account.
+//! - `FeesManager`: Implemented by `FeesManagerImpl`, providing the logic for calculating
+//!   subscription fees, managing fee differences, and collecting fees from subscribers.
+//! - `DepositCalculator`: Implemented by `DepositCalculatorImpl`, providing the logic for
+//!   calculating storage deposits and managing deposit differences.
 
 use crate::{
 	self as pallet_idn_manager,
@@ -48,12 +61,31 @@ impl SubscriptionTrait<()> for () {
 }
 
 /// A FeesManager implementation that holds a dynamic treasury account.
+///
+/// This implementation uses a dynamic treasury account specified in the `Config`
+/// to manage fees. It provides functions for calculating subscription fees,
+/// calculating the difference in fees, and collecting fees from subscribers.
+///
+/// # Type Parameters:
+/// * `Treasury`: A `Get<AccountId32>` implementation that provides the treasury account ID.
+/// * `BaseFee`: A `Get<Balances::Balance>` implementation that provides the base fee.
+/// * `Sub`: A `SubscriptionTrait<AccountId32>` implementation that provides access to subscription
+///   details.
+/// * `Balances`: A `Mutate<AccountId32>` implementation that provides the ability to hold and
+///   release balances.
 pub struct FeesManagerImpl<Treasury, BaseFee, Sub, Balances> {
 	pub _phantom: FeesManagerPhantom<Treasury, BaseFee, Sub, Balances>,
 }
+
 type FeesManagerPhantom<Treasury, BaseFee, Sub, Balances> =
 	(PhantomData<Treasury>, PhantomData<BaseFee>, PhantomData<Sub>, PhantomData<Balances>);
 
+/// Implementation of the FeesManager trait for the FeesManagerImpl struct.
+///
+/// # Tests
+///
+/// ## Calculate Subscription Fees Test
+#[doc = docify::embed!("./src/tests/pallet.rs", test_calculate_subscription_fees)]
 impl<
 		T: Get<AccountId32>,
 		B: Get<Balances::Balance>,
@@ -78,23 +110,6 @@ where
 	/// 1. For each tier, calculate how many credits fall within that tier
 	/// 2. Apply the corresponding discount rate to those credits
 	/// 3. Sum up the fees across all tiers
-	///
-	/// # Parameters
-	/// * `credits` - The total number of credits requested for the subscription
-	///
-	/// # Returns
-	/// The total fee required for the requested number of credits, converted to the
-	/// appropriate balance type
-	///
-	/// # Example
-	/// ```nocompile
-	/// // 100_000 credits would incur a fee of:
-	/// // - 10_000 credits at full price: 10_000 * 100 = 1_000_000
-	/// // - 90_000 credits at 5% discount: 90_000 * 95 = 8_550_000
-	/// // Total: 9_550_000
-	/// let fees = calculate_subscription_fees(&100u64);
-	/// assert_eq!(fees, 9_550_000u64.into());
-	/// ```
 	fn calculate_subscription_fees(credits: &u64) -> Balances::Balance {
 		// Define tier boundaries and their respective discount rates (in basis points)
 		const TIERS: [(u64, u64); 5] = [
@@ -143,41 +158,6 @@ where
 	/// then returns:
 	/// - The fee difference amount
 	/// - The direction of the balance transfer (collect from user, release to user, or no change)
-	///
-	/// # Parameters
-	/// * `old_credits`
-	///   - For an update operation, this represents the original requested credits
-	///   - For a kill and collect operation, this is the number of credits left in the subscription
-	/// * `new_credits`
-	///   - For an update operation, this represents the new requested credits
-	///   - For a kill operation, this is 0
-	///   - For a collect operation, this is the actual number of credits consumed
-	///
-	/// # Returns
-	/// A `DiffBalance` struct containing:
-	/// - `balance`: The amount of fees to collect or release
-	/// - `direction`: Whether to collect additional fees, release excess fees, or do nothing
-	///
-	/// # Examples
-	/// ```nocompile
-	/// // When increasing credits, additional fees are collected:
-	/// // Old: 10_000 credits (1_000 fee), New: 50_000 credits (5_000_000 fee)
-	/// let diff = calculate_diff_fees(&10_000, &50_000);
-	/// assert_eq!(diff.balance, 4_000_000);
-	/// assert_eq!(diff.direction, BalanceDirection::Collect);
-	///
-	/// // When decreasing credits, excess fees are released:
-	/// // Old: 100_000 credits (9_550_000 fee), New: 10_000 credits (1_000_000 fee)
-	/// let diff = calculate_diff_fees(&100_000, &10_000);
-	/// assert_eq!(diff.balance, 8_550_000);
-	/// assert_eq!(diff.direction, BalanceDirection::Release);
-	///
-	/// // When credits remain the same, no fee changes occur:
-	/// // Old: 50_000 credits (5_000_000 fee), New: 50_000 credits (5_000_000 fee)
-	/// let diff = calculate_diff_fees(&50_000, &50_000);
-	/// assert_eq!(diff.balance, 0);
-	/// assert_eq!(diff.direction, BalanceDirection::None);
-	/// ```
 	fn calculate_diff_fees(old_credits: &u64, new_credits: &u64) -> DiffBalance<Balances::Balance> {
 		let old_fees = Self::calculate_subscription_fees(old_credits);
 		let new_fees = Self::calculate_subscription_fees(new_credits);
@@ -204,14 +184,6 @@ where
 	/// 2. Verifies that the full fee amount was successfully collected
 	/// 3. Returns the actual amount collected or an appropriate error
 	///
-	/// # Parameters
-	/// * `fees` - The amount of fees to collect
-	/// * `sub` - The subscription object containing the subscriber account information
-	///
-	/// # Returns
-	/// - `Ok(collected)` - The amount of fees successfully collected and transferred
-	/// - `Err(FeesError)` - If the transfer operation fails
-	///
 	/// # Notes
 	/// - This function uses `transfer_on_hold` which transfers from the subscriber's held balance
 	/// - The fees are held under the `HoldReason::Fees` reason code
@@ -219,23 +191,6 @@ where
 	///   isn't available
 	/// - Despite using best effort, this function will return an error if less than the requested
 	///   amount is collected
-	///
-	/// # Example
-	/// ```nocompile
-	/// let fees = 1_000_000u64.into();
-	/// let result = FeesManagerImpl::<Treasury, BaseFee, Subscription, Balances>::collect_fees(
-	///     &fees,
-	///     &subscription
-	/// );
-	///
-	/// match result {
-	///     Ok(collected) => println!("Successfully collected {} in fees", collected),
-	///     Err(FeesError::NotEnoughBalance { needed, balance }) => {
-	///         println!("Insufficient balance: needed {}, had {}", needed, balance);
-	///     },
-	///     Err(FeesError::Other(err)) => println!("Transfer error: {:?}", err),
-	/// }
-	/// ```
 	fn collect_fees(
 		fees: &Balances::Balance,
 		sub: &S,
@@ -261,28 +216,29 @@ where
 	}
 
 	/// Get the number of credits consumed by a subscription when this one gets a pulse in a block.
-	///
-	/// # Parameters
-	/// * `_sub` - The subscription object
-	///
-	/// # Returns
-	/// The number of credits consumed
 	fn get_consume_credits(_sub: &S) -> u64 {
 		1000
 	}
 
 	/// Get the number of credits consumed by a subscription when this one is idle in a block.
-	///
-	/// # Parameters
-	/// * `_sub` - The subscription object
-	///
-	/// # Returns
-	/// The number of idle credits
 	fn get_idle_credits(_sub: &S) -> u64 {
 		10
 	}
 }
 
+/// A DepositCalculator implementation that uses a configurable deposit multiplier.
+///
+/// This struct is used to calculate the storage deposit required for a subscription. The deposit
+/// amount is calculated by multiplying the encoded size of the subscription data by the storage
+/// deposit multiplier.
+///
+/// # Tests
+///
+/// ## Hold Deposit Test
+#[doc = docify::embed!("./src/tests/pallet.rs", hold_deposit_works)]
+///
+/// ## Release Deposit Test
+#[doc = docify::embed!("./src/tests/pallet.rs", release_deposit_works)]
 pub struct DepositCalculatorImpl<SDMultiplier: Get<Deposit>, Deposit> {
 	pub _phantom: (PhantomData<SDMultiplier>, PhantomData<Deposit>),
 }
@@ -299,28 +255,11 @@ impl<
 	/// This function computes the storage deposit amount based on the encoded size of the
 	/// subscription object multiplied by a configurable deposit multiplier.
 	///
-	/// # Parameters
-	/// * `sub` - The subscription object for which to calculate the storage deposit
-	///
-	/// # Returns
-	/// The amount of deposit required for the subscription's storage
-	///
 	/// # Security Considerations
 	/// This function handles potential overflow scenarios by:
 	/// 1. Converting the encoded size from `usize` to `u64` with fallback to `u64::MAX` if the
 	///    conversion fails
 	/// 2. Using saturating multiplication to prevent arithmetic overflow
-	///
-	/// # Example
-	/// ```nocompile
-	/// let subscription = Subscription {
-	///     // subscription details...
-	/// };
-	///
-	/// // If SDMultiplier is 2 and the subscription encodes to 100 bytes:
-	/// let deposit = DepositCalculatorImpl::<SDMultiplier, u64>::calculate_storage_deposit(&subscription);
-	/// assert_eq!(deposit, 200_000);
-	/// ```
 	fn calculate_storage_deposit(sub: &S) -> Deposit {
 		// [SRLabs] Note: There is a theoretical edge case where if the `Deposit` type (e.g., u64)
 		// is larger than the machine architecture size (e.g., 32-bit platforms), an attacker
@@ -337,45 +276,11 @@ impl<
 	/// This function compares the storage deposit requirements of two subscription states
 	/// and returns the difference along with the direction of the balance adjustment.
 	///
-	/// # Parameters
-	/// * `old_sub` - The original subscription before changes
-	/// * `new_sub` - The updated subscription after changes
-	///
-	/// # Returns
-	/// A `DiffBalance` struct containing:
-	/// - `balance`: The absolute difference between the old and new deposit amounts
-	/// - `direction`: Whether to collect additional deposit, release excess deposit, or make no
-	///   change
-	///
 	/// # How It Works
 	/// 1. Calculates the storage deposit for both the old and new subscription states
 	/// 2. Compares the two deposits to determine if more deposit is needed, some can be released,
 	///    or no change is required
 	/// 3. Returns both the amount and direction of the required deposit adjustment
-	///
-	/// # Example
-	/// ```nocompile
-	/// // When subscription size increases (e.g., metadata added):
-	/// let old_sub = /* subscription with 100 bytes encoded size */;
-	/// let new_sub = /* same subscription with 150 bytes encoded size */;
-	///
-	/// // If SDMultiplier is 2:
-	/// // Old deposit = 2 * 100_000 = 200_000
-	/// // New deposit = 2 * 150_000 = 300_000
-	/// let diff = DepositCalculatorImpl::<SDMultiplier, u64>::calculate_diff_deposit(&old_sub, &new_sub);
-	/// assert_eq!(diff.balance, 100_000); // 300_000 - 200_000 = 100_000 more needed
-	/// assert_eq!(diff.direction, BalanceDirection::Collect);
-	///
-	/// // When subscription size decreases (e.g., metadata removed):
-	/// let old_sub = /* subscription with 150 bytes encoded size */;
-	/// let new_sub = /* same subscription with 100_000 bytes encoded size */;
-	///
-	/// // Old deposit = 2 * 150_000 = 300_000
-	/// // New deposit = 2 * 100_000 = 200_000
-	/// let diff = DepositCalculatorImpl::<SDMultiplier, u64>::calculate_diff_deposit(&old_sub, &new_sub);
-	/// assert_eq!(diff.balance, 100_000); // 300_000 - 200_000 = 100_000 to release
-	/// assert_eq!(diff.direction, BalanceDirection::Release);
-	/// ```
 	fn calculate_diff_deposit(old_sub: &S, new_sub: &S) -> DiffBalance<Deposit> {
 		let old_deposit = Self::calculate_storage_deposit(old_sub);
 		let new_deposit = Self::calculate_storage_deposit(new_sub);

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -22,11 +22,11 @@
 //!
 //! ## Key Implementations:
 //!
-//! - `SubscriptionTrait`: Implemented for the `Subscription` struct, providing access to
-//!   subscription details such as the subscriber account.
-//! - `FeesManager`: Implemented by `FeesManagerImpl`, providing the logic for calculating
+//! - [`Subscription Trait`](SubscriptionTrait): Implemented for the [`Subscription`] struct,
+//!   providing access to subscription details such as the subscriber account.
+//! - [`FeesManager`]: Implemented by [`FeesManagerImpl`], providing the logic for calculating
 //!   subscription fees, managing fee differences, and collecting fees from subscribers.
-//! - `DepositCalculator`: Implemented by `DepositCalculatorImpl`, providing the logic for
+//! - [`DepositCalculator`]: Implemented by [`DepositCalculatorImpl`], providing the logic for
 //!   calculating storage deposits and managing deposit differences.
 
 use crate::{
@@ -42,6 +42,7 @@ use frame_support::{
 		Get,
 	},
 };
+use pallet_idn_manager::{DepositCalculator, FeesManager};
 use sp_arithmetic::traits::Unsigned;
 use sp_runtime::{traits::Zero, AccountId32, Saturating};
 use sp_std::{cmp::Ordering, marker::PhantomData};
@@ -91,7 +92,7 @@ impl<
 		B: Get<Balances::Balance>,
 		S: SubscriptionTrait<AccountId32>,
 		Balances: Mutate<AccountId32>,
-	> pallet_idn_manager::FeesManager<Balances::Balance, u64, S, DispatchError, AccountId32>
+	> FeesManager<Balances::Balance, u64, S, DispatchError, AccountId32>
 	for FeesManagerImpl<T, B, S, Balances>
 where
 	Balances::Reason: From<HoldReason>,
@@ -185,9 +186,11 @@ where
 	/// 3. Returns the actual amount collected or an appropriate error
 	///
 	/// # Notes
-	/// - This function uses `transfer_on_hold` which transfers from the subscriber's held balance
-	/// - The fees are held under the `HoldReason::Fees` reason code
-	/// - The transfer uses `Precision::BestEffort` which allows partial transfers if full amount
+	/// - This function uses
+	///   [`transfer_on_hold`](frame_support::traits::tokens::fungible::hold::Mutate::transfer_on_hold)
+	///   which transfers from the subscriber's held balance
+	/// - The fees are held under the [`HoldReason::Fees`] reason code
+	/// - The transfer uses [`Precision::BestEffort`] which allows partial transfers if full amount
 	///   isn't available
 	/// - Despite using best effort, this function will return an error if less than the requested
 	///   amount is collected
@@ -247,8 +250,7 @@ impl<
 		S: SubscriptionTrait<AccountId32> + Encode,
 		SDMultiplier: Get<Deposit>,
 		Deposit: Saturating + From<u64> + Ord,
-	> pallet_idn_manager::DepositCalculator<Deposit, S>
-	for DepositCalculatorImpl<SDMultiplier, Deposit>
+	> DepositCalculator<Deposit, S> for DepositCalculatorImpl<SDMultiplier, Deposit>
 {
 	/// Calculate the storage deposit required for a subscription.
 	///

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -275,7 +275,7 @@ pub type CreateSubParamsOf<T> = CreateSubParams<
 pub struct UpdateSubParams<SubId, Credits, Frequency, PulseFilter> {
 	// The Subscription Id
 	pub sub_id: SubId,
-	// New number of pulses
+	// New number of credits
 	pub credits: Credits,
 	// New distribution interval
 	pub frequency: Frequency,

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -739,7 +739,7 @@ impl<T: Config> Pallet<T> {
 					// see the [Pulse Filtering Security](#pulse-filtering-security) section
 					Self::custom_filter(&sub.pulse_filter, &pulse)
 				{
-					let msg = Self::construct_randomness_xcm(&pulse, sub.details.call_index);
+					let msg = Self::construct_xcm_msg(&pulse, sub.details.call_index);
 					let versioned_target: Box<VersionedLocation> =
 						Box::new(sub.details.target.clone().into());
 					let versioned_msg: Box<VersionedXcm<()>> =
@@ -949,7 +949,7 @@ impl<T: Config> Pallet<T> {
 	/// 2. Execute a call on the destination chain using the provided call index and randomness data
 	///    ([`Transact`])
 	/// 3. Expect successful execution and check status code (ExpectTransactStatus)
-	fn construct_randomness_xcm(pulse: &T::Pulse, call_index: CallIndex) -> Xcm<()> {
+	fn construct_xcm_msg(pulse: &T::Pulse, call_index: CallIndex) -> Xcm<()> {
 		Xcm(vec![
 			UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 			Transact {

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -16,22 +16,15 @@
 
 //! # IDN Manager Pallet
 //!
-//! This pallet manages subscriptions for random value distribution.
+//! This pallet manages subscriptions for pulse distribution.
 //!
 //! ## Subscription State Lifecycle
-//! ```mermaid
-//! stateDiagram-v2
-//!     [*] --> Active
-//!     Active --> Paused
-//!     Paused --> Active
-//!     Paused --> [*]
-//!     Active --> [*]
-//! ```
+#![doc = simple_mermaid::mermaid!("../docs/mermaid/sub_state_lifecycle.mmd")]
 //! ### States
 //!
 //! 1. Active (Default)
 //!    - Randomness is actively distributed
-//!    - IDN delivers random values according to subscription parameters
+//!    - IDN delivers pulses according to subscription parameters
 //!
 //! 2. Paused
 //!    - Randomness distribution temporarily suspended
@@ -40,7 +33,7 @@
 //!
 //! ### Termination
 //! Subscription ends when:
-//! - All allocated random values are consumed
+//! - All allocated pulses are consumed
 //! - Manually killed by the original caller
 //!
 //! Upon termination:
@@ -56,14 +49,14 @@
 //! randomness values.
 //!
 //! ### Security Concern
-//! If filtering by random values were allowed, a subscriber could potentially:
+//! If filtering by pulses were allowed, a subscriber could potentially:
 //! - Set up filters to only receive specific randomness patterns
-//! - Game the system by cherry-picking favorable random values
+//! - Game the system by cherry-picking favorable pulses
 //! - Undermine the fairness and unpredictability of the randomness distribution
 //!
 //! ### Implementation Approach
 //! The [`ensure_filter_no_rand`](Pallet::ensure_filter_no_rand) function validates that
-//! filters don't contain any random value criteria. This validation happens when the filter
+//! filters don't contain any pulse criteria. This validation happens when the filter
 //! is first created or updated, rather than during distribution:
 //!
 //! - **Benefits**: The filter validation cost is paid by the subscriber creating the filter, not
@@ -144,11 +137,14 @@ pub use weights::WeightInfo;
 /// to the appropriate function in the destination pallet.
 pub type CallIndex = [u8; 2];
 
+/// The balance type used in the pallet, derived from the currency type in the configuration.
 pub type BalanceOf<T> =
 	<<T as Config>::Currency as Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 
+/// The metadata type used in the pallet, represented as a bounded vector of bytes.
 pub type MetadataOf<T> = BoundedVec<u8, <T as Config>::SubMetadataLen>;
 
+/// The subscription type used in the pallet, containing various details about the subscription.
 pub type SubscriptionOf<T> = Subscription<
 	<T as frame_system::Config>::AccountId,
 	BlockNumberFor<T>,
@@ -157,6 +153,7 @@ pub type SubscriptionOf<T> = Subscription<
 	PulseFilterOf<T>,
 >;
 
+/// The pulse property type used in the pallet, representing various properties of a pulse.
 pub type PulsePropertyOf<T> = PulseProperty<
 	<<T as pallet::Config>::Pulse as Pulse>::Rand,
 	<<T as pallet::Config>::Pulse as Pulse>::Round,
@@ -190,11 +187,12 @@ pub type PulsePropertyOf<T> = PulseProperty<
 /// See the [Pulse Filtering Security](#pulse-filtering-security) section for more details.
 pub type PulseFilterOf<T> = BoundedVec<PulsePropertyOf<T>, <T as Config>::PulseFilterLen>;
 
+/// Represents a subscription in the system.
 #[derive(Encode, Decode, Clone, TypeInfo, MaxEncodedLen, Debug)]
 pub struct Subscription<AccountId, BlockNumber, Credits, Metadata, PulseFilter> {
 	id: SubscriptionId,
 	details: SubscriptionDetails<AccountId, Metadata>,
-	// Number of random values left to distribute
+	// Number of pulses left to distribute
 	credits_left: Credits,
 	state: SubscriptionState,
 	created_at: BlockNumber,
@@ -205,17 +203,10 @@ pub struct Subscription<AccountId, BlockNumber, Credits, Metadata, PulseFilter> 
 	pulse_filter: Option<PulseFilter>,
 }
 
-/// Details specific to a subscription for random value delivery
+/// Details specific to a subscription for pulse delivery
 ///
 /// This struct contains information about the subscription owner, where randomness should be
 /// delivered, how to deliver it via XCM, and any additional metadata for the subscription.
-///
-/// # Fields
-/// * `subscriber` - The account that created and pays for the subscription
-/// * `target` - The XCM location where randomness should be delivered
-/// * `call_index` - Identifier for dispatching the XCM call, see [`crate::CallIndex`]
-/// * `metadata` - Optional bounded metadata that can be used by the subscriber for identification
-///   or application-specific data
 ///
 /// # Example
 /// ```rust
@@ -243,21 +234,24 @@ pub struct SubscriptionDetails<AccountId, Metadata> {
 	pub metadata: Metadata,
 }
 
+/// The subscription details type used in the pallet, containing information about the subscription
+/// owner and target.
 pub type SubscriptionDetailsOf<T> =
 	SubscriptionDetails<<T as frame_system::Config>::AccountId, MetadataOf<T>>;
 
+/// The subscription ID type used in the pallet, represented as a 32-byte array.
 pub type SubscriptionId = [u8; 32];
 
 /// Parameters for creating a new subscription
 #[derive(Encode, Decode, Clone, TypeInfo, MaxEncodedLen, Debug, PartialEq)]
 pub struct CreateSubParams<Credits, BlockNumber, Metadata, PulseFilter> {
-	// Number of random values to receive
+	// Number of pulses to receive
 	pub credits: Credits,
-	// XCM multilocation for random value delivery
+	// XCM multilocation for pulse delivery
 	pub target: Location,
 	// Call index for XCM message
 	pub call_index: CallIndex,
-	// Distribution interval for random values
+	// Distribution interval for pulses
 	pub frequency: BlockNumber,
 	// Bounded vector for additional data
 	pub metadata: Option<Metadata>,
@@ -267,6 +261,8 @@ pub struct CreateSubParams<Credits, BlockNumber, Metadata, PulseFilter> {
 	pub sub_id: Option<SubscriptionId>,
 }
 
+/// The parameters for creating a new subscription, containing various details about the
+/// subscription.
 pub type CreateSubParamsOf<T> = CreateSubParams<
 	<T as pallet::Config>::Credits,
 	BlockNumberFor<T>,
@@ -279,7 +275,7 @@ pub type CreateSubParamsOf<T> = CreateSubParams<
 pub struct UpdateSubParams<SubId, Credits, Frequency, PulseFilter> {
 	// The Subscription Id
 	pub sub_id: SubId,
-	// New number of random values
+	// New number of pulses
 	pub credits: Credits,
 	// New distribution interval
 	pub frequency: Frequency,
@@ -287,12 +283,25 @@ pub struct UpdateSubParams<SubId, Credits, Frequency, PulseFilter> {
 	pub pulse_filter: Option<PulseFilter>,
 }
 
+/// The parameters for updating an existing subscription, containing various details about the
+/// subscription.
 pub type UpdateSubParamsOf<T> =
 	UpdateSubParams<SubscriptionId, <T as Config>::Credits, BlockNumberFor<T>, PulseFilterOf<T>>;
 
+/// Represents the state of a subscription.
+///
+/// This enum defines the possible states of a subscription, which can be either active or paused.
+///
+/// # Variants
+/// * `Active` - The subscription is active and randomness is being distributed.
+/// * `Paused` - The subscription is paused and randomness distribution is temporarily suspended.
+///
+/// See [Subscription State Lifecycle](./index.html#subscription-state-lifecycle) for more details.
 #[derive(Encode, Decode, Clone, PartialEq, TypeInfo, MaxEncodedLen, Debug)]
 pub enum SubscriptionState {
+	/// The subscription is active and randomness is being distributed.
 	Active,
+	/// The subscription is paused and randomness distribution is temporarily suspended.
 	Paused,
 }
 
@@ -361,6 +370,7 @@ pub mod pallet {
 		type MaxSubscriptions: Get<u32>;
 	}
 
+	/// The subscription storage. It maps a subscription ID to a subscription.
 	#[pallet::storage]
 	pub(crate) type Subscriptions<T: Config> =
 		StorageMap<_, Blake2_128Concat, SubscriptionId, SubscriptionOf<T>, OptionQuery>;
@@ -401,7 +411,7 @@ pub mod pallet {
 		SubscriptionAlreadyPaused,
 		/// The origin isn't the subscriber
 		NotSubscriber,
-		/// Can't filter out based on random values
+		/// Can't filter out based on pulses
 		FilterRandNotPermitted,
 		/// Too many subscriptions in storage
 		TooManySubscriptions,
@@ -433,7 +443,19 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		/// Creates a subscription for one or multiple blocks
+		/// Creates a subscription in the pallet.
+		///
+		/// This function allows a user to create a new subscription for receiving pulses.
+		/// The subscription includes details such as the number of credits, target location, call
+		/// index, frequency, metadata, and an optional pulse filter.
+		///
+		/// # Errors
+		/// * `TooManySubscriptions` - If the maximum number of subscriptions has been reached.
+		/// * `FilterNoRand` - If the pulse filter contains pulses.
+		/// * `SubscriptionAlreadyExists` - If a subscription with the specified ID already exists.
+		///
+		/// # Events
+		/// * `SubscriptionCreated` - A new subscription has been created.
 		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::create_subscription(T::PulseFilterLen::get()))]
 		#[allow(clippy::useless_conversion)]
@@ -448,7 +470,7 @@ pub mod pallet {
 				Error::<T>::TooManySubscriptions
 			);
 
-			// make sure the filter does not filter on random values
+			// make sure the filter does not filter on pulses
 			// see the [Pulse Filtering Security](#pulse-filtering-security) section
 			Self::ensure_filter_no_rand(&params.pulse_filter)?;
 
@@ -506,7 +528,18 @@ pub mod pallet {
 			.into())
 		}
 
-		/// Temporarily halts randomness distribution
+		/// Temporarily halts randomness distribution for a subscription.
+		///
+		/// This function allows the subscriber to pause their subscription,
+		/// which temporarily halts the distribution of pulses.
+		///
+		/// # Errors
+		/// * `SubscriptionDoesNotExist` - If a subscription with the specified ID does not exist.
+		/// * `NotSubscriber` - If the origin is not the subscriber of the specified subscription.
+		/// * `SubscriptionAlreadyPaused` - If the subscription is already paused.
+		///
+		/// # Events
+		/// * `SubscriptionPaused` - A subscription has been paused.
 		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::pause_subscription())]
 		pub fn pause_subscription(
@@ -528,7 +561,17 @@ pub mod pallet {
 			})
 		}
 
-		/// Ends the subscription before its natural conclusion
+		/// Ends the subscription before its natural conclusion.
+		///
+		/// This function allows the subscriber to terminate their subscription early,
+		/// which stops the distribution of pulses and refunds any unused credits.
+		///
+		/// # Errors
+		/// * `SubscriptionDoesNotExist` - If a subscription with the specified ID does not exist.
+		/// * `NotSubscriber` - If the origin is not the subscriber of the specified subscription.
+		///
+		/// # Events
+		/// * `SubscriptionRemoved` - A subscription has been terminated.
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::kill_subscription())]
 		pub fn kill_subscription(
@@ -545,7 +588,18 @@ pub mod pallet {
 			Self::finish_subscription(&sub, sub_id)
 		}
 
-		/// Updates a subscription
+		/// Updates a subscription.
+		///
+		/// This function allows the subscriber to modify their subscription parameters,
+		/// such as the number of credits, distribution interval, and pulse filter.
+		///
+		/// # Errors
+		/// * `SubscriptionDoesNotExist` - If a subscription with the specified ID does not exist.
+		/// * `NotSubscriber` - If the origin is not the subscriber of the specified subscription.
+		/// * `FilterNoRand` - If the pulse filter contains random values.
+		///
+		/// # Events
+		/// * `SubscriptionUpdated` - A subscription has been updated.
 		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::update_subscription(T::PulseFilterLen::get()))]
 		#[allow(clippy::useless_conversion)]
@@ -556,7 +610,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let subscriber = ensure_signed(origin)?;
 
-			// make sure the filter does not filter on random values
+			// make sure the filter does not filter on pulses
 			// see the [Pulse Filtering Security](#pulse-filtering-security) section
 			Self::ensure_filter_no_rand(&params.pulse_filter)?;
 
@@ -591,7 +645,16 @@ pub mod pallet {
 			.into())
 		}
 
-		/// Reactivates a paused subscription
+		/// Reactivates a paused subscription.
+		///
+		/// This function allows the subscriber to resume a paused subscription,
+		/// which restarts the distribution of pulses.
+		///
+		/// # Parameters
+		/// * `origin` - The origin of the transaction, must be a signed account.
+		/// * `sub_id` - The ID of the subscription to reactivate.
+		/// # Events
+		/// * `SubscriptionReactivated` - A subscription has been reactivated.
 		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::reactivate_subscription())]
 		pub fn reactivate_subscription(
@@ -701,6 +764,24 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	/// Collects fees for a subscription based on credits consumed.
+	///
+	/// This internal helper function calculates and collects fees from a subscription based on
+	/// the number of credits consumed. If no credits are consumed, no fees are collected.
+	///
+	/// It calculates the fees to collect using `T::FeesManager::calculate_diff_fees`, which
+	/// determines the difference between the current credits left and the credits left after
+	/// consumption.
+	/// It collects the fees using `T::FeesManager::collect_fees`, transferring the fees from the
+	/// subscriber's account to the treasury.
+	///
+	/// # Errors
+	/// * `DispatchError::Other("NotEnoughBalance")` - If the subscriber does not have enough
+	///   balance to pay the fees.
+	/// * `FeesError::Other(de)` - If there is another error during fee collection.
+	///
+	/// # Events
+	/// * `FeesCollected` - Emitted when fees are successfully collected from the subscription.
 	fn collect_fees(sub: &SubscriptionOf<T>, credits_consumed: T::Credits) -> DispatchResult {
 		if credits_consumed.is_zero() {
 			return Ok(());
@@ -723,14 +804,6 @@ impl<T: Config> Pallet<T> {
 	/// This function checks whether a given pulse meets the filter criteria specified
 	/// in a subscription. If no filter is present, all pulses pass through.
 	///
-	/// # Parameters
-	/// * `pulse_filter` - Optional filters to apply to the pulse
-	/// * `pulse` - The pulse to check against the filter
-	///
-	/// # Returns
-	/// * `true` - If the pulse passes the filter or if no filter is specified
-	/// * `false` - If the pulse does not match the filter criteria
-	///
 	/// # How Filtering Works
 	/// 1. If `pulse_filter` is `None`, returns `true` (no filtering)
 	/// 2. Otherwise, checks if ANY of the properties in the filter match the pulse using the
@@ -745,6 +818,13 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
+	/// Generates a unique subscription ID.
+	///
+	/// This internal helper function generates a unique subscription ID based on the
+	/// subscription details and the current block number.
+	///
+	/// The subscription ID is generated using a combination of the subscription details and the
+	/// current block number to ensure uniqueness and prevent collisions.
 	fn generate_sub_id(
 		sub_details: &SubscriptionDetailsOf<T>,
 		current_block: &BlockNumberFor<T>,
@@ -762,15 +842,26 @@ impl<T: Config> Pallet<T> {
 		H256::from_slice(&blake2_256(&encoded)).into()
 	}
 
+	/// Holds fees for a subscription.
+	///
+	/// This internal helper function places a hold on the specified fees in the subscriber's
+	/// account.
 	fn hold_fees(subscriber: &T::AccountId, fees: BalanceOf<T>) -> DispatchResult {
 		T::Currency::hold(&HoldReason::Fees.into(), subscriber, fees)
 	}
 
+	/// Releases fees for a subscription.
+	///
+	/// This internal helper function releases the specified fees from the subscriber's account.
 	fn release_fees(subscriber: &T::AccountId, fees: BalanceOf<T>) -> DispatchResult {
 		let _ = T::Currency::release(&HoldReason::Fees.into(), subscriber, fees, Precision::Exact)?;
 		Ok(())
 	}
 
+	/// Manages the difference in fees for a subscription.
+	///
+	/// This internal helper function manages the difference in fees for a subscription, either
+	/// collecting additional fees or releasing excess fees.
 	fn manage_diff_fees(
 		subscriber: &T::AccountId,
 		diff: &DiffBalance<BalanceOf<T>>,
@@ -782,10 +873,18 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
+	/// Holds a storage deposit for a subscription.
+	///
+	/// This internal helper function places a hold on the specified storage deposit in the
+	/// subscriber's account.
 	fn hold_deposit(subscriber: &T::AccountId, deposit: BalanceOf<T>) -> DispatchResult {
 		T::Currency::hold(&HoldReason::StorageDeposit.into(), subscriber, deposit)
 	}
 
+	/// Releases a storage deposit for a subscription.
+	///
+	/// This internal helper function releases the specified storage deposit from the subscriber's
+	/// account.
 	fn release_deposit(subscriber: &T::AccountId, deposit: BalanceOf<T>) -> DispatchResult {
 		let _ = T::Currency::release(
 			&HoldReason::StorageDeposit.into(),
@@ -796,23 +895,16 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	/// Ensures that a pulse filter doesn't attempt to filter on random values
+	/// Ensures that a pulse filter doesn't attempt to filter on pulses
 	///
 	/// This function checks that the filter doesn't use the `PulseProperty::Rand` or
 	/// `PulseProperty::Sig` variant for filtering. Filtering based on randomness is not permitted
 	/// because it would contradict the purpose of randomness distribution - clients shouldn't be
-	/// able to selectively receive only certain random values.
-	///
-	/// # Parameters
-	/// * `pulse_filter` - The optional pulse filter to validate
-	///
-	/// # Returns
-	/// * `Ok(())` - If the filter is either not present or doesn't filter on random values
-	/// * `Err(Error::FilterRandNotPermitted)` - If the filter attempts to filter on random values
+	/// able to selectively receive only certain pulses.
 	///
 	/// # Security Notes
 	/// This function is an important security check that prevents subscribers from
-	/// potentially gaming the system by receiving only certain random values that
+	/// potentially gaming the system by receiving only certain pulses that
 	/// match specific patterns.
 	pub fn ensure_filter_no_rand(pulse_filter: &Option<PulseFilterOf<T>>) -> DispatchResult {
 		if let Some(filter) = pulse_filter {
@@ -826,6 +918,10 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	/// Manages the difference in storage deposit for a subscription.
+	///
+	/// This internal helper function manages the difference in storage deposit for a subscription,
+	/// either collecting additional deposit or releasing excess deposit.
 	fn manage_diff_deposit(
 		subscriber: &T::AccountId,
 		diff: &DiffBalance<BalanceOf<T>>,
@@ -844,13 +940,6 @@ impl<T: Config> Pallet<T> {
 	/// 2. Execute a call on the destination chain using the provided call index and randomness data
 	///    (Transact)
 	/// 3. Expect successful execution and check status code (ExpectTransactStatus)
-	///
-	/// # Parameters
-	/// * `pulse` - The random value to deliver to the subscriber
-	/// * `call_index` - Identifier for dispatching the XCM call, see [`crate::CallIndex`]
-	///
-	/// # Returns
-	/// * `Xcm` - A complete XCM message ready to be sent
 	fn construct_randomness_xcm(pulse: &T::Pulse, call_index: CallIndex) -> Xcm<()> {
 		Xcm(vec![
 			UnpaidExecution { weight_limit: Unlimited, check_origin: None },
@@ -861,24 +950,32 @@ impl<T: Config> Pallet<T> {
 				// to Vec<u8> The encoded data will be used by the receiving chain to:
 				// 1. Find the target pallet using first byte of call_index
 				// 2. Find the target function using second byte of call_index
-				// 3. Pass the random value to that function
+				// 3. Pass the pulse to that function
 				call: (call_index, pulse).encode().into(),
 			},
 			ExpectTransactStatus(MaybeErrorCode::Success),
 		])
 	}
 
-	/// Computes the fee for a given credits
+	/// Computes the fee for a given number of credits.
+	///
+	/// This function calculates the subscription fee based on the specified number of credits
+	/// using the `FeesManager` implementation.
 	pub fn calculate_subscription_fees(credits: &T::Credits) -> BalanceOf<T> {
 		T::FeesManager::calculate_subscription_fees(credits)
 	}
 
-	/// Retrieves a specific subscription
+	/// Retrieves a specific subscription by its ID.
+	///
+	/// This function retrieves a subscription from storage based on the provided subscription ID.
 	pub fn get_subscription(sub_id: &SubscriptionId) -> Option<SubscriptionOf<T>> {
 		Subscriptions::<T>::get(sub_id)
 	}
 
-	/// Retrieves all subscriptions for a specific subscriber
+	/// Retrieves all subscriptions for a specific subscriber.
+	///
+	/// This function retrieves all subscriptions from storage that are associated with the
+	/// provided subscriber account.
 	pub fn get_subscriptions_for_subscriber(subscriber: &T::AccountId) -> Vec<SubscriptionOf<T>> {
 		Subscriptions::<T>::iter()
 			.filter(|(_, sub)| &sub.details.subscriber == subscriber)
@@ -888,6 +985,11 @@ impl<T: Config> Pallet<T> {
 }
 
 impl<T: Config> Dispatcher<T::Pulse, DispatchResult> for Pallet<T> {
+	/// Dispatches a given pulse by distributing it to eligible subscriptions.
+	///
+	/// This function serves as the entry point for distributing randomness pulses
+	/// to active subscriptions. It calls the `distribute` function to handle the
+	/// actual distribution logic.
 	fn dispatch(pulse: T::Pulse) -> DispatchResult {
 		Pallet::<T>::distribute(pulse)
 	}
@@ -905,7 +1007,7 @@ sp_api::decl_runtime_apis! {
 		///
 		/// See [`crate::Pallet::calculate_subscription_fees`]
 		fn calculate_subscription_fees(
-			// Number of random values to receive
+			// Number of pulses to receive
 			credits: Credits
 		) -> Balance;
 

--- a/pallets/idn-manager/src/tests/pallet.rs
+++ b/pallets/idn-manager/src/tests/pallet.rs
@@ -1247,6 +1247,7 @@ fn test_on_finalize_removes_finished_subscriptions() {
 }
 
 #[test]
+#[docify::export_content]
 fn hold_deposit_works() {
 	ExtBuilder::build().execute_with(|| {
 		let initial_balance = 10_000_000;
@@ -1269,6 +1270,7 @@ fn hold_deposit_works() {
 }
 
 #[test]
+#[docify::export_content]
 fn release_deposit_works() {
 	ExtBuilder::build().execute_with(|| {
 		let initial_balance = 10_000_000;
@@ -1365,9 +1367,11 @@ fn hold_deposit_fails_with_insufficient_balance() {
 }
 
 #[test]
+#[docify::export_content]
 fn test_calculate_subscription_fees() {
 	ExtBuilder::build().execute_with(|| {
 		// Test with different credit amounts
+		// The tuples in these cases are (credits, expected_fee)
 		let test_cases = vec![
 			(0, 0),                  // Zero credits
 			(1_000, 100_000),        // 1k credits

--- a/pallets/idn-manager/src/traits.rs
+++ b/pallets/idn-manager/src/traits.rs
@@ -14,13 +14,91 @@
  * limitations under the License.
  */
 
-//! # Traits
+//! # Traits for the IDN Manager Pallet
+//!
+//! This file defines the traits that enable the IDN Manager pallet to interact seamlessly with
+//! other components within the blockchain ecosystem. These traits abstract key functionalities,
+//! promoting modularity, flexibility, and testability.
+//!
+//! ## Core Concepts:
+//!
+//! - **Fees Management:** Governs the calculation, collection, and distribution of fees associated
+//!   with subscriptions.
+//! - **Subscription Handling:** Provides a standardized way to access subscriber information.
+//! - **Storage Deposit Calculation:** Defines the logic for determining and managing storage
+//!   deposits required for subscriptions.
+//!
+//! ## Key Traits:
+//!
+//! ### `FeesManager`
+//! Manages the economic aspects of subscriptions, including fee calculation, collection, and
+//! distribution.
+//!
+//! **Methods:**
+//!   - `calculate_subscription_fees`: Determines the initial fee for a subscription based on the
+//!     requested credits.
+//!   - `calculate_diff_fees`: Calculates the difference in fees when a subscription is modified
+//!     (e.g., credits are added or removed).
+//!   - `collect_fees`: Transfers fees from the subscriber's account to the designated treasury.
+//!   - `get_consume_credits`: Returns the amount of credits consumed when a subscription receives a
+//!     pulse.
+//!   - `get_idle_credits`: Returns the amount of credits consumed when a subscription skips
+//!     receiving a pulse.
+//!
+//! ### `Subscription`
+//! Provides a simple interface for accessing the subscriber associated with a subscription.
+//!
+//! **Methods:**
+//!   - `subscriber`: Returns the account ID of the subscriber.
+//!
+//! ### `DepositCalculator`
+//! Manages the storage deposits required for subscriptions, ensuring that sufficient funds are
+//! reserved to cover the cost of storing subscription data.
+//!
+//! **Methods:**
+//!   - `calculate_storage_deposit`: Calculates the storage deposit required for a given
+//!     subscription.
+//!   - `calculate_diff_deposit`: Calculates the difference in storage deposit between two
+//!     subscriptions (e.g., when a subscription is updated).
+//!
+//! ## Data Structures:
+//!
+//! ### `FeesError`
+//! Represents potential errors that can occur during fees management.
+//!
+//! **Variants:**
+//!   - `NotEnoughBalance`: Indicates that the subscriber's account has insufficient funds to cover
+//!     the required fees.
+//!   - `Other`: Represents a generic error with an associated context.
+//!
+//! ### `BalanceDirection`
+//! Specifies the direction of balance movement (either collecting or releasing funds).
+//!
+//! **Variants:**
+//!   - `Collect`: Indicates that funds should be collected from the subscriber.
+//!   - `Release`: Indicates that funds should be released to the subscriber.
+//!   - `None`: Indicates that no balance movement is required.
+//!
+//! ### `DiffBalance`
+//! Represents a change in balance, including the amount and direction of the change.
+//!
+//! **Fields:**
+//!   - `balance`: The amount of balance being moved.
+//!   - `direction`: The direction of the balance movement (using the `BalanceDirection` enum).
 
 /// Error type for fees management
 ///
 /// Context is used to provide more information about uncategorized errors.
 pub enum FeesError<Fees, Context> {
-	NotEnoughBalance { needed: Fees, balance: Fees },
+	/// Error indicating that the balance is insufficient to cover the required fees.
+	///
+	/// # Variants
+	/// - `needed`: The amount of fees required.
+	/// - `balance`: The current balance available.
+	NotEnoughBalance {
+		needed: Fees,
+		balance: Fees,
+	},
 	Other(Context),
 }
 
@@ -44,6 +122,18 @@ pub struct DiffBalance<Balance> {
 }
 
 /// Trait for fees managing
+///
+/// This is where the bussines model logic is specified. This logic is used to calculate, collect
+/// and distribute fees for subscriptions.
+///
+/// You can check the a particular implementation of this trait in
+/// [FeesManagerImpl](crate::impls::FeesManagerImpl).
+///
+/// These are some examples of how this trait can be implemented:
+/// - Linear fee calculator: where the fees are calculated based on a linear function.
+#[doc = docify::embed!("./src/tests/fee_examples.rs", linear_fee_calculator)]
+/// - Tiered fee calculator: where the fees are calculated based on a tiered function.
+#[doc = docify::embed!("./src/tests/fee_examples.rs", tiered_fee_calculator)]
 pub trait FeesManager<Fees, Credits, Sub: Subscription<S>, Err, S> {
 	/// Calculate the fees for a subscription based on the credits of pulses required.
 	fn calculate_subscription_fees(credits: &Credits) -> Fees;
@@ -62,7 +152,9 @@ pub trait FeesManager<Fees, Credits, Sub: Subscription<S>, Err, S> {
 	fn get_idle_credits(sub: &Sub) -> Credits;
 }
 
+/// Trait for accessing subscription information.
 pub trait Subscription<Subscriber> {
+	/// Returns a reference to the subscriber associated with the subscription.
 	fn subscriber(&self) -> &Subscriber;
 }
 

--- a/pallets/idn-manager/src/traits.rs
+++ b/pallets/idn-manager/src/traits.rs
@@ -16,9 +16,8 @@
 
 //! # Traits for the IDN Manager Pallet
 //!
-//! This file defines the traits that enable the IDN Manager pallet to interact seamlessly with
-//! other components within the blockchain ecosystem. These traits abstract key functionalities,
-//! promoting modularity, flexibility, and testability.
+//! This file defines the traits that enable the IDN Manager pallet to interact with other modules.
+//! These traits abstract key functionalities.
 //!
 //! ## Core Concepts:
 //!
@@ -30,61 +29,66 @@
 //!
 //! ## Key Traits:
 //!
-//! ### `FeesManager`
+//! ### [`FeesManager`]
 //! Manages the economic aspects of subscriptions, including fee calculation, collection, and
 //! distribution.
 //!
 //! **Methods:**
-//!   - `calculate_subscription_fees`: Determines the initial fee for a subscription based on the
-//!     requested credits.
-//!   - `calculate_diff_fees`: Calculates the difference in fees when a subscription is modified
-//!     (e.g., credits are added or removed).
-//!   - `collect_fees`: Transfers fees from the subscriber's account to the designated treasury.
-//!   - `get_consume_credits`: Returns the amount of credits consumed when a subscription receives a
-//!     pulse.
-//!   - `get_idle_credits`: Returns the amount of credits consumed when a subscription skips
-//!     receiving a pulse.
+//!   - [`calculate_subscription_fees`](FeesManager::calculate_subscription_fees): Determines the
+//!     initial fee for a subscription based on the requested credits.
+//!   - [`calculate_diff_fees`](FeesManager::calculate_diff_fees): Calculates the difference in fees
+//!     when a subscription is modified (e.g., credits are added or removed).
+//!   - [`collect_fees`](FeesManager::collect_fees): Transfers fees from the subscriber's account to
+//!     the designated treasury.
+//!   - [`get_consume_credits`](FeesManager::get_consume_credits): Returns the amount of credits
+//!     that should be consumed when a subscription receives a pulse.
+//!   - [`get_idle_credits`](FeesManager::get_idle_credits): Returns the amount of credits that
+//!     should be consumed when a subscription skips receiving a pulse.
 //!
-//! ### `Subscription`
-//! Provides a simple interface for accessing the subscriber associated with a subscription.
+//! ### [`Subscription`]
+//! Provides an interface for accessing the subscriber associated with a subscription.
 //!
 //! **Methods:**
-//!   - `subscriber`: Returns the account ID of the subscriber.
+//!   - [`subscriber`](Subscription::subscriber): Returns the account ID of the subscriber.
 //!
-//! ### `DepositCalculator`
+//! ### [`DepositCalculator`]
 //! Manages the storage deposits required for subscriptions, ensuring that sufficient funds are
 //! reserved to cover the cost of storing subscription data.
 //!
 //! **Methods:**
-//!   - `calculate_storage_deposit`: Calculates the storage deposit required for a given
-//!     subscription.
-//!   - `calculate_diff_deposit`: Calculates the difference in storage deposit between two
-//!     subscriptions (e.g., when a subscription is updated).
+//!   - [`calculate_storage_deposit`](DepositCalculator::calculate_storage_deposit): Calculates the
+//!     storage deposit required for a given subscription.
+//!   - [`calculate_diff_deposit`](DepositCalculator::calculate_diff_deposit): Calculates the
+//!     difference in storage deposit between two subscriptions (e.g., when a subscription is
+//!     updated).
 //!
 //! ## Data Structures:
 //!
-//! ### `FeesError`
+//! ### [`FeesError`]
 //! Represents potential errors that can occur during fees management.
 //!
 //! **Variants:**
-//!   - `NotEnoughBalance`: Indicates that the subscriber's account has insufficient funds to cover
-//!     the required fees.
-//!   - `Other`: Represents a generic error with an associated context.
+//!   - [`NotEnoughBalance`](FeesError::NotEnoughBalance): Indicates that the subscriber's account
+//!     has insufficient funds to cover the required fees.
+//!   - [`Other`](FeesError::Other): Represents a generic error with an associated context.
 //!
-//! ### `BalanceDirection`
+//! ### [`BalanceDirection`]
 //! Specifies the direction of balance movement (either collecting or releasing funds).
 //!
 //! **Variants:**
-//!   - `Collect`: Indicates that funds should be collected from the subscriber.
-//!   - `Release`: Indicates that funds should be released to the subscriber.
-//!   - `None`: Indicates that no balance movement is required.
+//!   - [`Collect`](BalanceDirection::Collect): Indicates that funds should be collected from the
+//!     subscriber.
+//!   - [`Release`](BalanceDirection::Release): Indicates that funds should be released to the
+//!     subscriber.
+//!   - [`None`](BalanceDirection::None): Indicates that no balance movement is required.
 //!
-//! ### `DiffBalance`
+//! ### [`DiffBalance`]
 //! Represents a change in balance, including the amount and direction of the change.
 //!
 //! **Fields:**
-//!   - `balance`: The amount of balance being moved.
-//!   - `direction`: The direction of the balance movement (using the `BalanceDirection` enum).
+//!   - [`balance`](DiffBalance::balance): The amount of balance being moved.
+//!   - [`direction`](DiffBalance::direction): The direction of the balance movement (using the
+//!     `BalanceDirection` enum).
 
 /// Error type for fees management
 ///

--- a/pallets/idn-manager/src/traits.rs
+++ b/pallets/idn-manager/src/traits.rs
@@ -127,7 +127,7 @@ pub struct DiffBalance<Balance> {
 
 /// Trait for fees managing
 ///
-/// This is where the bussines model logic is specified. This logic is used to calculate, collect
+/// This is where the business model logic is specified. This logic is used to calculate, collect
 /// and distribute fees for subscriptions.
 ///
 /// You can check the a particular implementation of this trait in


### PR DESCRIPTION
close #78 

# Docs/idn manager pallet

This pull request adds documentation for the IDN Manager pallet.

- Adds detailed README for the IDN Manager pallet.
- Introduces Mermaid diagrams for visualizing state transitions.
- Updates dependencies to include documentation generation tools.
- Enhances code comments and docstrings for better clarity.
- Updates the GitHub Actions workflow to check for docs generation.

## Description

### Documentation Enhancements

1. **Detailed README**:
   - Added a comprehensive README file for the IDN Manager pallet.

2. **Mermaid Diagrams**:
   - Introduced Mermaid diagrams to visualize the subscription state lifecycle.
   - Added `sub_state_lifecycle.mmd` to the documentation directory.

3. **Code Comments and Docstrings**:
   - Enhanced code comments and docstrings for better clarity and understanding.
   - Added detailed explanations for key functions and internal logic.