### PR TITLE
Create seperate build jobs for chains

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Build
       run: cargo build --all-features --verbose --exclude idn-sdk-kitchensink-runtime --exclude idn-sdk-kitchensink-node --exclude idn-consumer-runtime --exclude idn-consumer-node --exclude idn-runtime --exclude idn-node --workspace
       
-  build_chains:
-    runs-on: ubuntu-latest-m
+  build_idn_kitchen_sink:
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -43,14 +43,52 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-rust
 
-      - name: Run cargo clippy for chains
-        run: cargo clippy --all-features -p idn-sdk-kitchensink-runtime -p idn-sdk-kitchensink-node -p idn-node -p idn-runtime -- -D warnings
+      - name: Run cargo clippy
+        run: cargo clippy --all-features -p idn-sdk-kitchensink-node -- -D warnings
 
       - name: Run cargo doc for chains
-        run: cargo doc --no-deps --all-features -p idn-sdk-kitchensink-runtime -p idn-sdk-kitchensink-node -p idn-consumer-runtime -p idn-consumer-node -p idn-runtime -p idn-node
+        run: cargo doc --no-deps --all-features -p idn-sdk-kitchensink-node
         
       - name: Build
-        run: cargo build --all-features --verbose -p idn-sdk-kitchensink-runtime -p idn-sdk-kitchensink-node -p idn-consumer-runtime -p idn-consumer-node -p idn-runtime -p idn-node
+        run: cargo build --all-features --verbose -p idn-sdk-kitchensink-node
+
+    build_idn_consumer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-rust
+
+      - name: Run cargo clippy
+        run: cargo clippy --all-features -p idn-consumer-node -- -D warnings
+
+      - name: Run cargo doc for chains
+        run: cargo doc --no-deps --all-features -p idn-consumer-node
+        
+      - name: Build
+        run: cargo build --all-features --verbose -p idn-consumer-node
+    
+    build_idn:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-rust
+
+      - name: Run cargo clippy
+        run: cargo clippy --all-features -p idn-node -- -D warnings
+
+      - name: Run cargo doc for chains
+        run: cargo doc --no-deps --all-features -p idn-node
+        
+      - name: Build
+        run: cargo build --all-features --verbose -p idn-node
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,42 +53,42 @@ jobs:
         run: cargo build --all-features --verbose -p idn-sdk-kitchensink-node
 
   build_idn_consumer:
-  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup Environment
-      uses: ./.github/actions/setup-rust
+      - name: Setup Environment
+        uses: ./.github/actions/setup-rust
 
-    - name: Run cargo clippy
-      run: cargo clippy --all-features -p idn-consumer-node -- -D warnings
+      - name: Run cargo clippy
+        run: cargo clippy --all-features -p idn-consumer-node -- -D warnings
 
-    - name: Run cargo doc for chains
-      run: cargo doc --no-deps --all-features -p idn-consumer-node
+      - name: Run cargo doc for chains
+        run: cargo doc --no-deps --all-features -p idn-consumer-node
         
-    - name: Build
-      run: cargo build --all-features --verbose -p idn-consumer-node
+      - name: Build
+        run: cargo build --all-features --verbose -p idn-consumer-node
     
   build_idn:
-  runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup Environment
-      uses: ./.github/actions/setup-rust
+      - name: Setup Environment
+        uses: ./.github/actions/setup-rust
 
-    - name: Run cargo clippy
-      run: cargo clippy --all-features -p idn-node -- -D warnings
+      - name: Run cargo clippy
+        run: cargo clippy --all-features -p idn-node -- -D warnings
+
+      - name: Run cargo doc for chains
+        run: cargo doc --no-deps --all-features -p idn-node
       
-    - name: Run cargo doc for chains
-      run: cargo doc --no-deps --all-features -p idn-node
-      
-    - name: Build
-      run: cargo build --all-features --verbose -p idn-node
+      - name: Build
+        run: cargo build --all-features --verbose -p idn-node
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
       run: cargo build --all-features --verbose --exclude idn-sdk-kitchensink-runtime --exclude idn-sdk-kitchensink-node --exclude idn-consumer-runtime --exclude idn-consumer-node --exclude idn-runtime --exclude idn-node --workspace
       
   build_chains:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
 
     steps:
       - name: Checkout code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-rust
       - name: Check disk Space
-        run: dh -h
+        run: df -h
 
       - name: Run cargo clippy
         run: cargo clippy --all-features -p idn-sdk-kitchensink-node -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-rust
+      - name: Check disk Space
+        run: dh -h
 
       - name: Run cargo clippy
         run: cargo clippy --all-features -p idn-sdk-kitchensink-node -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,12 +43,6 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-rust
 
-      - name: Check disk Space
-        run: df -h
-      
-      - name: Check pwd
-        run: pwd
-
       - name: Run cargo clippy
         run: cargo clippy --all-features -p idn-sdk-kitchensink-node -- -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
         run: cargo doc --no-deps --all-features -p idn-consumer-node
         
       - name: Build
-        run: cargo build --verbose -p idn-consumer-node
+        run: cargo build --verbose -p idn-consumer-node --release
     
   build_idn:
     runs-on: ubuntu-latest
@@ -94,7 +94,7 @@ jobs:
         run: cargo doc --no-deps --all-features -p idn-node
       
       - name: Build
-        run: cargo build --verbose -p idn-node
+        run: cargo build --verbose -p idn-node --release
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,43 +52,43 @@ jobs:
       - name: Build
         run: cargo build --all-features --verbose -p idn-sdk-kitchensink-node
 
-    build_idn_consumer:
-    runs-on: ubuntu-latest
+  build_idn_consumer:
+  runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-rust
+    - name: Setup Environment
+      uses: ./.github/actions/setup-rust
 
-      - name: Run cargo clippy
-        run: cargo clippy --all-features -p idn-consumer-node -- -D warnings
+    - name: Run cargo clippy
+      run: cargo clippy --all-features -p idn-consumer-node -- -D warnings
 
-      - name: Run cargo doc for chains
-        run: cargo doc --no-deps --all-features -p idn-consumer-node
+    - name: Run cargo doc for chains
+      run: cargo doc --no-deps --all-features -p idn-consumer-node
         
-      - name: Build
-        run: cargo build --all-features --verbose -p idn-consumer-node
+    - name: Build
+      run: cargo build --all-features --verbose -p idn-consumer-node
     
-    build_idn:
-    runs-on: ubuntu-latest
+  build_idn:
+  runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
 
-      - name: Setup Environment
-        uses: ./.github/actions/setup-rust
+    - name: Setup Environment
+      uses: ./.github/actions/setup-rust
 
-      - name: Run cargo clippy
-        run: cargo clippy --all-features -p idn-node -- -D warnings
-
-      - name: Run cargo doc for chains
-        run: cargo doc --no-deps --all-features -p idn-node
-        
-      - name: Build
-        run: cargo build --all-features --verbose -p idn-node
+    - name: Run cargo clippy
+      run: cargo clippy --all-features -p idn-node -- -D warnings
+      
+    - name: Run cargo doc for chains
+      run: cargo doc --no-deps --all-features -p idn-node
+      
+    - name: Build
+      run: cargo build --all-features --verbose -p idn-node
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,25 @@ jobs:
 
     - name: Build
       run: cargo build --all-features --verbose --exclude idn-sdk-kitchensink-runtime --exclude idn-sdk-kitchensink-node --exclude idn-consumer-runtime --exclude idn-consumer-node --exclude idn-runtime --exclude idn-node --workspace
+      
+  build_chains:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-rust
+
+      - name: Run cargo clippy for chains
+        run: cargo clippy --all-features -p idn-sdk-kitchensink-runtime -p idn-sdk-kitchensink-node -p idn-node -p idn-runtime -- -D warnings
+
+      - name: Run cargo doc for chains
+        run: cargo doc --no-deps --all-features -p idn-sdk-kitchensink-runtime -p idn-sdk-kitchensink-node -p idn-consumer-runtime -p idn-consumer-node -p idn-runtime -p idn-node
+        
+      - name: Build
+        run: cargo build --all-features --verbose -p idn-sdk-kitchensink-runtime -p idn-sdk-kitchensink-node -p idn-consumer-runtime -p idn-consumer-node -p idn-runtime -p idn-node
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
         run: cargo doc --no-deps --all-features -p idn-consumer-node
         
       - name: Build
-        run: cargo build --all-features --verbose -p idn-consumer-node
+        run: cargo build --verbose -p idn-consumer-node
     
   build_idn:
     runs-on: ubuntu-latest
@@ -94,7 +94,7 @@ jobs:
         run: cargo doc --no-deps --all-features -p idn-node
       
       - name: Build
-        run: cargo build --all-features --verbose -p idn-node
+        run: cargo build --verbose -p idn-node
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,8 +42,12 @@ jobs:
 
       - name: Setup Environment
         uses: ./.github/actions/setup-rust
+
       - name: Check disk Space
         run: df -h
+      
+      - name: Check pwd
+        run: pwd
 
       - name: Run cargo clippy
         run: cargo clippy --all-features -p idn-sdk-kitchensink-node -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
         run: cargo doc --no-deps --all-features -p idn-consumer-node
         
       - name: Build
-        run: cargo build --verbose -p idn-consumer-node --release
+        run: cargo build --verbose --all-features -p idn-consumer-node --release
     
   build_idn:
     runs-on: ubuntu-latest
@@ -88,7 +88,7 @@ jobs:
         run: cargo doc --no-deps --all-features -p idn-node
       
       - name: Build
-        run: cargo build --verbose -p idn-node --release
+        run: cargo build --verbose --all-features -p idn-node --release
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR addresses the storage issues we were encountering on github runners in regards to building our nodes and runtimes.