### PR TITLE
decouple pallet manager from randomness beacon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9819,7 +9819,6 @@ dependencies = [
  "hex",
  "log",
  "pallet-balances",
- "pallet-idn-manager",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/pallets/randomness-beacon/Cargo.toml
+++ b/pallets/randomness-beacon/Cargo.toml
@@ -38,8 +38,6 @@ ark-serialize.workspace = true
 ark-ec.workspace = true
 ark-std.workspace = true
 
-pallet-idn-manager = { workspace = true, default-features = false }
-
 [dev-dependencies]
 sp-keystore.workspace = true
 sp-inherents.workspace = true
@@ -62,7 +60,6 @@ std = [
 	"sp-runtime/std",
 	"serde/std",
 	"hex/std",
-
 	"ark-bls12-381/std",
 	"ark-serialize/std",
 	"ark-ec/std",
@@ -70,7 +67,6 @@ std = [
 	"sp-consensus-randomness-beacon/std",
 	"sp-idn-traits/std",
 	"sp-std/std",
-	"pallet-idn-manager/std",
 	"pallet-balances/std",
 ]
 runtime-benchmarks = [
@@ -78,7 +74,6 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	"pallet-idn-manager/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks"
 ]
 try-runtime = [

--- a/pallets/randomness-beacon/src/mock.rs
+++ b/pallets/randomness-beacon/src/mock.rs
@@ -56,16 +56,6 @@ impl pallet_drand_bridge::Config for Test {
 	type Dispatcher = MockDispatcher;
 }
 
-parameter_types! {
-	pub const PalletId: frame_support::PalletId = frame_support::PalletId(*b"idn_mngr");
-	pub const TreasuryAccount: AccountId32 = AccountId32::new([123u8; 32]);
-	pub const BaseFee: u64 = 10;
-	pub const SDMultiplier: u64 = 10;
-	pub const MaxPulseFilterLen: u32 = 100;
-	pub const MaxSubscriptions: u32 = 100;
-	pub const MaxMetadataLen: u32 = 8;
-}
-
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();

--- a/pallets/randomness-beacon/src/mock.rs
+++ b/pallets/randomness-beacon/src/mock.rs
@@ -33,9 +33,9 @@ impl pallet_balances::Config for Test {
 	type AccountStore = System;
 }
 
-pub struct Dispatcher;
+pub struct MockDispatcher;
 impl sp_idn_traits::pulse::Dispatcher<RuntimePulse, Result<(), sp_runtime::DispatchError>>
-	for Dispatcher
+	for MockDispatcher
 {
 	fn dispatch(_pulses: Vec<RuntimePulse>) -> Result<(), sp_runtime::DispatchError> {
 		Ok(())
@@ -53,7 +53,7 @@ impl pallet_drand_bridge::Config for Test {
 	type MaxSigsPerBlock = ConstU8<10>;
 	type MissedBlocksHistoryDepth = ConstU32<{ u8::MAX as u32 }>;
 	type Pulse = RuntimePulse;
-	type Dispatcher = Dispatcher;
+	type Dispatcher = MockDispatcher;
 }
 
 parameter_types! {


### PR DESCRIPTION
This PR removes the pallet-idn-manager dependency from the pallet-randomness-beacon, using a mock instead for testing