### PR TITLE
fix/h2x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16539,7 +16539,6 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "tokio",
- "w3f-bls",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,6 @@ ark-ec = { version = "0.4.0", default-features = false }
 ark-ff = { version = "0.4.0", default-features = false }
 ark-std = { version = "0.4.0", default-features = false }
 sha2 = { version = "0.10.2", default-features = false }
-w3f-bls = { version = "=0.1.9", default-features = false }
 
 # Logging & Utilities
 clap = { version = "4.5.26", features = ["derive"] }

--- a/primitives/crypto/Cargo.toml
+++ b/primitives/crypto/Cargo.toml
@@ -34,7 +34,6 @@ ark-bls12-381.workspace = true
 ark-ff.workspace = true
 ark-serialize.workspace = true
 ark-std.workspace = true
-w3f-bls.workspace = true
 
 [dev-dependencies]
 array-bytes = "=6.2.3"
@@ -60,5 +59,4 @@ std = [
 	"ark-ff/std",
 	"ark-serialize/std",
 	"ark-std/std",
-	"w3f-bls/std"
 ]

--- a/primitives/crypto/src/bls12_381.rs
+++ b/primitives/crypto/src/bls12_381.rs
@@ -27,6 +27,8 @@ pub enum CryptoError {
 	DeserializeG1Failure,
 	/// The data could not be deserialized to a valid element of G2.
 	DeserializeG2Failure,
+	/// The hash-to-curve map could not be obtained
+	HashToCurveFailure,
 	/// No data could be serialized from a valid element of G1.
 	SerializeG1Failure,
 	/// No data could be serialized from a valid element of G2.

--- a/primitives/crypto/src/drand.rs
+++ b/primitives/crypto/src/drand.rs
@@ -22,127 +22,22 @@ use sp_std::vec::Vec;
 use ark_ec::{
 	bls12::Bls12Config,
 	hashing::{
-		curve_maps::wb::{WBConfig, WBMap},
-		map_to_curve_hasher::{MapToCurve, MapToCurveBasedHasher},
+		curve_maps::wb::WBMap,
+		map_to_curve_hasher::MapToCurveBasedHasher,
 		HashToCurve,
 	},
-	pairing::{MillerLoopOutput, Pairing},
-	AffineRepr, CurveGroup,
+	pairing::Pairing,
 };
 use ark_ff::field_hashers::DefaultFieldHasher;
-use core::marker::PhantomData;
-use w3f_bls::EngineBLS;
-
 use ark_bls12_381::G1Affine;
 
+/// The context string when hashing round numbers to G1
 pub const QUICKNET_CTX: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
 
-pub type TinyBLS381 = TinyBLSDrandQuicknet<ark_bls12_381::Bls12_381, ark_bls12_381::Config>;
-
-/// Trait to add extra config for a curve which is not in ArkWorks library
-pub trait CurveExtraConfig {
-	const CURVE_NAME: &'static [u8];
-}
-
-/// Aggregate BLS signature scheme with Signature in G1 for BLS12-381 curve.
-impl CurveExtraConfig for ark_bls12_381::Config {
-	const CURVE_NAME: &'static [u8] = b"BLS12381";
-}
-
-/// A BLS variant with tiny 48 byte signatures and 96 byte public keys,
-///
-/// Specifically, this configuration is used by Drand's QuickNet.
-/// It is a slightly modified version of the w3f/bls library's
-/// [TinyBLS381](https://github.com/w3f/bls/blob/85c4f76a64671c4cfa3ac713983a263f96709f0c/src/engine.rs#L348) implementation.
-/// However, the TinyBLS381 implementation is inflexible and uses a hardcoded
-/// value for domain separation when computing the hash to curve map.
-///
-/// Note on performance: verifiers  always perform `O(signers)` additions on the
-/// `PublicKeyGroup`, or worse 128 bit scalar multiplications with
-/// delinearization. Yet, there are specific use cases where this variant
-/// performs better.  We swapy two group roles relative to zcash here.
-#[derive(Default)]
-pub struct TinyBLSDrandQuicknet<E: Pairing, P: Bls12Config + CurveExtraConfig>(
-	pub E,
-	PhantomData<fn() -> P>,
-)
-where
-	<P as Bls12Config>::G1Config: WBConfig,
-	WBMap<<P as Bls12Config>::G1Config>: MapToCurve<<E as Pairing>::G1>;
-
-/// The implementation
-impl<E: Pairing, P: Bls12Config + CurveExtraConfig> EngineBLS for TinyBLSDrandQuicknet<E, P>
-where
-	<P as Bls12Config>::G1Config: WBConfig,
-	WBMap<<P as Bls12Config>::G1Config>: MapToCurve<<E as Pairing>::G1>,
-{
-	type Engine = E;
-	type Scalar = <Self::Engine as Pairing>::ScalarField;
-
-	type SignatureGroup = E::G1;
-	type SignatureGroupAffine = E::G1Affine;
-	type SignaturePrepared = E::G1Prepared;
-	type SignatureGroupBaseField = <<E as Pairing>::G1 as CurveGroup>::BaseField;
-
-	const SIGNATURE_SERIALIZED_SIZE: usize = 48;
-
-	type PublicKeyGroup = E::G2;
-	type PublicKeyGroupAffine = E::G2Affine;
-	type PublicKeyPrepared = E::G2Prepared;
-	type PublicKeyGroupBaseField = <<E as Pairing>::G2 as CurveGroup>::BaseField;
-
-	const PUBLICKEY_SERIALIZED_SIZE: usize = 96;
-	const SECRET_KEY_SIZE: usize = 32;
-
-	const CURVE_NAME: &'static [u8] = P::CURVE_NAME;
-	const SIG_GROUP_NAME: &'static [u8] = b"G1";
-	const CIPHER_SUIT_DOMAIN_SEPARATION: &'static [u8] = b"_XMD:SHA-256_SSWU_RO_";
-
-	type HashToSignatureField = DefaultFieldHasher<Sha256, 128>;
-	type MapToSignatureCurve = WBMap<P::G1Config>;
-
-	fn miller_loop<'a, I>(i: I) -> MillerLoopOutput<E>
-	where
-		I: IntoIterator<Item = &'a (Self::PublicKeyPrepared, Self::SignaturePrepared)>,
-	{
-		// We require an ugly unecessary allocation here because
-		// zcash's pairing library consumes an iterator of references
-		// to tuples of references, which always requires
-		let (i_a, i_b): (Vec<Self::PublicKeyPrepared>, Vec<Self::SignaturePrepared>) =
-			i.into_iter().cloned().unzip();
-
-		E::multi_miller_loop(i_b, i_a) //in Tiny BLS signature is in G1
-	}
-
-	fn pairing<G2, G1>(p: G2, q: G1) -> E::TargetField
-	where
-		G1: Into<E::G1Affine>,
-		G2: Into<E::G2Affine>,
-	{
-		E::pairing(q.into(), p.into()).0
-	}
-
-	/// Prepared negative of the generator of the public key curve.
-	fn minus_generator_of_public_key_group_prepared() -> Self::PublicKeyPrepared {
-		let g2_minus_generator = <Self::PublicKeyGroup as CurveGroup>::Affine::generator();
-		<Self::PublicKeyGroup as Into<Self::PublicKeyPrepared>>::into(
-			-g2_minus_generator.into_group(),
-		)
-	}
-
-	fn hash_to_curve_map() -> MapToCurveBasedHasher<
-		Self::SignatureGroup,
-		Self::HashToSignatureField,
-		Self::MapToSignatureCurve,
-	> {
-		MapToCurveBasedHasher::<
-			Self::SignatureGroup,
-			DefaultFieldHasher<Sha256, 128>,
-			WBMap<P::G1Config>,
-		>::new(QUICKNET_CTX)
-		.expect("The MapToCurveBasedHasher can be built from the specified types and input, qed.")
-	}
-}
+/// The bls12-381 curve
+type E = ark_bls12_381::Bls12_381;
+/// The bls12-381 curve config
+type Config = ark_bls12_381::Config;
 
 /// Constructs a message (e.g. signed by drand)
 fn message(current_round: u64, prev_sig: &[u8]) -> Vec<u8> {
@@ -153,11 +48,14 @@ fn message(current_round: u64, prev_sig: &[u8]) -> Vec<u8> {
 }
 
 /// This computes the point on G1 given a round number (for message construction).
-// TODO: do we save anything by pulling out the hasher instead of constructing it each time?
-// https://github.com/ideal-lab5/idn-sdk/issues/119
 pub fn compute_round_on_g1(round: u64) -> Result<G1Affine, CryptoError> {
 	let message = message(round, &[]);
-	let hasher = <TinyBLS381 as EngineBLS>::hash_to_curve_map();
+	let hasher = MapToCurveBasedHasher::<
+			<E as Pairing>::G1,
+			DefaultFieldHasher<Sha256, 128>,
+			WBMap<<Config as Bls12Config>::G1Config>,
+		>::new(QUICKNET_CTX)
+		.map_err(|_| CryptoError::HashToCurveFailure)?;
 	// H(m) \in G1
 	let message_hash = hasher.hash(&message).map_err(|_| CryptoError::InvalidBuffer)?;
 


### PR DESCRIPTION
- closes #263 
- closes #218 

This PR removes the EngineBLS impl that required a hash-to-curve constructor that returns a concrete type instead of a result. However, in reality the function *does* return a result. At present, an error can only be encountered when the test feature is enable, however, we want to be sure we are properly future-proof. This PR instead fetches the H2C within the compute_round_in_g1 function, where we can easily handle the result by introducing a new `CryptoError` entry, `HashToCurveFailure`. 