### PR TITLE
fix accept relay native token reserve transfers

### DIFF
--- a/chains/ideal-network/network.toml
+++ b/chains/ideal-network/network.toml
@@ -14,7 +14,7 @@ chain = "paseo-local"
   validator = true
 
 [[parachains]]
-id = 1000
+id = 4502
 
   [[parachains.collators]]
   name = "idn-alice"

--- a/chains/ideal-network/node/src/chain_spec.rs
+++ b/chains/ideal-network/node/src/chain_spec.rs
@@ -16,7 +16,7 @@
 
 use cumulus_primitives_core::ParaId;
 use idn_runtime as runtime;
-use runtime::{AccountId, AuraId, Signature, EXISTENTIAL_DEPOSIT};
+use runtime::{AccountId, AuraId, Signature};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
@@ -148,17 +148,7 @@ pub fn local_testnet_config() -> ChainSpec {
 				.unwrap()
 				.into(),
 		],
-		vec![
-			sr25519::Public::from_str("5DG98CDpGab5LbqDCxJFdJrF6eDCVgKpdZqSEmWzcZA5Hq88") // seed: "//Idn-local-testnet-collator-01"
-				.unwrap()
-				.into(),
-			sr25519::Public::from_str("5FHLJBPPa8R9SW4vBXLMsWQkQiX2J2ZczJNgtLpy46AkLx6T") // seed: "//Idn-local-testnet-collator-02"
-				.unwrap()
-				.into(),
-			sr25519::Public::from_str("5Cu7qY3UMoejWDnzR1ZVfEUgVTqzJnvM6AE5FTnqard4dRP2") // seed: "//Idn-local-testnet-root"
-				.unwrap()
-				.into(),
-		],
+		vec![],
 		sr25519::Public::from_str("5Cu7qY3UMoejWDnzR1ZVfEUgVTqzJnvM6AE5FTnqard4dRP2") // seed: "//Idn-local-testnet-root"
 			.unwrap()
 			.into(),
@@ -194,17 +184,7 @@ pub fn testnet_config() -> ChainSpec {
 				.unwrap()
 				.into(),
 		],
-		vec![
-			sr25519::Public::from_str("5CLVQw6AiHywt4w8RgqueWVvRCyRkjQiJsNfESDV2AsMdY2V") // idn-testnet-01
-				.unwrap()
-				.into(),
-			sr25519::Public::from_str("5HDgmRx8pKeDGstHZrAMFzcRsXc3VFwf4yH6PQSJUvky7vHN") // idn-testnet-02
-				.unwrap()
-				.into(),
-			sr25519::Public::from_str("5Dcz93bWaQZuvjrgizvnPDSZDefrCFm4R58zsPmChrTe1ywQ") // idn-testnet-root
-				.unwrap()
-				.into(),
-		],
+		vec![],
 		sr25519::Public::from_str("5Dcz93bWaQZuvjrgizvnPDSZDefrCFm4R58zsPmChrTe1ywQ") // idn-testnet-root
 			.unwrap()
 			.into(),
@@ -230,7 +210,7 @@ fn testnet_genesis(
 		},
 		"collatorSelection": {
 			"invulnerables": invulnerables.clone(),
-			"candidacyBond": EXISTENTIAL_DEPOSIT * 16,
+			"candidacyBond": 0,
 		},
 		"session": {
 			"keys": invulnerables

--- a/chains/ideal-network/runtime/src/configs/xcm.rs
+++ b/chains/ideal-network/runtime/src/configs/xcm.rs
@@ -152,13 +152,15 @@ impl xcm_executor::Config for XcmConfig {
 	// How to withdraw and deposit an asset.
 	type AssetTransactor = FungibleTransactor;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	// IDN chain does not recognize a reserve location for any asset. Users must teleport
-	// DOT where allowed (e.g. with the Relay Chain).
-	type IsReserve = ();
-	/// Only allow teleportation of DOT.
+	/// Only allow reserve transfer of Relay Chain native token (e.g. DOT) from System or Relay
+	/// Chain.
+	type IsReserve = ConcreteAssetFromSystem<RelayLocation>;
+	/// Only allow teleportation of Relay Chain native token (e.g. DOT) from System or Relay
+	/// Chain.
 	type IsTeleporter = ConcreteAssetFromSystem<RelayLocation>;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
+	// TODO: use WeightInfoBounds https://github.com/ideal-lab5/idn-sdk/issues/262
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 	type Trader =
 		UsingComponents<WeightToFee, RelayLocation, AccountId, Balances, ToAuthor<Runtime>>;
@@ -210,6 +212,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = Everything;
 	type XcmReserveTransferFilter = Nothing;
+	// TODO: use WeightInfoBounds https://github.com/ideal-lab5/idn-sdk/issues/262
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 	type UniversalLocation = UniversalLocation;
 	type RuntimeOrigin = RuntimeOrigin;


### PR DESCRIPTION
Allow the relay and system chains to reserve transfer native relay chain token to the ideal network.
Additionally, as we can now transfer tokens from the relay, and the relay chain tokens are the native Ideal Network tokens, the initial balance has been removed from the testnet genesis.