### PR TITLE
Fix: gossipsub swarm restart listener

### DIFF
--- a/chains/ideal-network/node/src/service.rs
+++ b/chains/ideal-network/node/src/service.rs
@@ -427,7 +427,7 @@ pub async fn start_parachain_node(
 	if validator {
 		let (tx, rx) = tracing_unbounded("drand-notification-channel", 10000);
 		let pulse_receiver = DrandReceiver::<MAX_QUEUE_SIZE>::new(rx);
-		
+
 		let primary: Multiaddr =
 			PRIMARY.parse().expect("The string is a well-formatted multiaddress;qed");
 		let secondary: Multiaddr =

--- a/chains/ideal-network/node/src/service.rs
+++ b/chains/ideal-network/node/src/service.rs
@@ -23,7 +23,9 @@ use std::{sync::Arc, time::Duration};
 // Local Runtime Types
 use idn_runtime::{
 	apis::RuntimeApi,
-	constants::idn::{MAX_QUEUE_SIZE, PRIMARY, QUICKNET_GOSSIPSUB_TOPIC, SECONDARY},
+	constants::idn::{
+		MAX_QUEUE_SIZE, NO_MESSAGE_TIMEOUT, PRIMARY, QUICKNET_GOSSIPSUB_TOPIC, SECONDARY,
+	},
 	opaque::{Block, Hash},
 };
 
@@ -423,26 +425,26 @@ pub async fn start_parachain_node(
 	})?;
 
 	if validator {
-		// setup a libp2p node for gossipsub
 		let (tx, rx) = tracing_unbounded("drand-notification-channel", 10000);
-		let pulse_receiver = DrandReceiver::new(rx);
+		let pulse_receiver = DrandReceiver::<MAX_QUEUE_SIZE>::new(rx);
+		let peers = default_peers();
 
-		let local_identity: Keypair = Keypair::generate_ed25519();
-		let cfg = GossipsubConfig::default();
-		// [SRLabs] If the gossipsub network fails to construct we consider it a critical failure
-		let mut gossipsub = GossipsubNetwork::new(&local_identity, cfg, tx, None)
-			.expect("The gossipsub network must start.");
 		let primary: Multiaddr =
 			PRIMARY.parse().expect("The string is a well-formatted multiaddress;qed");
 		let secondary: Multiaddr =
 			SECONDARY.parse().expect("The string is a well-formatted multiaddress;qed");
+		let peers = &[primary, secondary];
 
-		tokio::spawn(async move {
-			if let Err(e) = gossipsub.run(QUICKNET_GOSSIPSUB_TOPIC, vec![primary, secondary]).await
-			{
-				log::error!("Failed to run gossipsub network: {:?}", e);
-			}
-		});
+		if let Err(e) = RetryableGossipsubRunner::<MAX_QUEUE_SIZE, NO_MESSAGE_TIMEOUT>::run(
+			topic_str,
+			peers,
+			tx.clone(),
+			drand_receiver.clone(),
+		) {
+			// if the retryable gossipsub runner fails we consider it a critical error
+			// and bring down the node
+			panic!("A critical error occurred - bringing down the node: {:?}", e);
+		}
 
 		start_consensus(
 			client.clone(),

--- a/chains/ideal-network/runtime/src/constants/idn.rs
+++ b/chains/ideal-network/runtime/src/constants/idn.rs
@@ -27,3 +27,5 @@ pub const SECONDARY: &str =
 	"/ip4/54.193.191.250/tcp/44544/p2p/12D3KooWQqDi3D3KLfDjWATQUUE4o5aSshwBFi9JM36wqEPMPD5y";
 /// The maximum queue size for the mpsc channel that stores raw pulse data (protobuf)
 pub const MAX_QUEUE_SIZE: usize = 100;
+/// The number of seconds the node waits without a new message until it restarts the swarm
+pub const NO_MESSAGE_TIMEOUT: usize = 12;

--- a/chains/kitchensink/node/Cargo.toml
+++ b/chains/kitchensink/node/Cargo.toml
@@ -21,7 +21,7 @@ futures = { features = ["thread-pool"], workspace = true }
 futures-timer.workspace = true
 jsonrpsee = { features = ["server"], workspace = true }
 libp2p = { workspace = true }
-log.workspace = true 
+log.workspace = true
 serde_json = { workspace = true, default-features = true }
 tokio.workspace = true
 sc-basic-authorship = { workspace = true, default-features = false }
@@ -54,6 +54,4 @@ substrate-build-script-utils = { workspace = true, default-features = false }
 
 [features]
 default = ["std"]
-std = [
-	"idn-sdk-kitchensink-runtime/std",
-]
+std = ["idn-sdk-kitchensink-runtime/std"]

--- a/chains/kitchensink/node/src/lib.rs
+++ b/chains/kitchensink/node/src/lib.rs
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 pub mod chain_spec;
 pub(crate) mod cli;
 pub mod rpc;

--- a/chains/kitchensink/node/src/service.rs
+++ b/chains/kitchensink/node/src/service.rs
@@ -218,7 +218,7 @@ pub fn new_full<Network: sc_network::NetworkBackend<Block, <Block as BlockT>::Ha
 			.expect("The string is a well-formatted multiaddress. qed.");
 	let maddr2: Multiaddr =
 		"/ip4/54.193.191.250/tcp/44544/p2p/12D3KooWQqDi3D3KLfDjWATQUUE4o5aSshwBFi9JM36wqEPMPD5y"
-			.parse() 
+			.parse()
 			.expect("The string is a well-formatted multiaddress. qed.");
 
 	let peers = vec![maddr1, maddr2];

--- a/client/consensus/randomness-beacon/src/gossipsub.rs
+++ b/client/consensus/randomness-beacon/src/gossipsub.rs
@@ -207,7 +207,7 @@ impl TracingEvent {
 /// N is the retry timeout for resyncing with the swarm
 pub struct RetryableGossipsubRunner<const M: usize, const N: usize>;
 impl<const M: usize, const N: usize> RetryableGossipsubRunner<M, N> {
-	pub fn run<'a>(
+	pub fn run(
 		topic_str: &'static str,
 		peers: Vec<Multiaddr>,
 		tx: TracingUnboundedSender<CanonicalPulse>,


### PR DESCRIPTION
Closes #277 

This PR introduces a new `RetryableGossipsubRunner` struct that can be used to gracefully restart the libp2p swarm when required. More specifically, this libp2p swarm is uniquely responsible for ingesting pulses from drand and is an isolated instance from the underlying libp2p node used in the Substrate framework. 

Before the change, on occasion (~50% of the time) on node initialization, we are able to generate the libp2p identity and ping peers as expected, however, the peers themselves would fail to include our new node into the gossipsub mesh (see [here](https://discuss.libp2p.io/t/mesh-fanout-and-peers-gossipsub-clarification/106) for clarification on terminology).  As a result, even though we can ping peers we never actually get messages from the gossipsub topic. In addition to this, this change is also intended to mitigate any eventual disconnects (e.g. as seen here https://discuss.libp2p.io/t/gossipsub-stops-propagating-messages-after-some-time-only-resumes-after-server-restart/2598).

