### PR TITLE
Adding initial account balances to idn chain spec

### DIFF
--- a/chains/ideal-network/node/src/chain_spec.rs
+++ b/chains/ideal-network/node/src/chain_spec.rs
@@ -148,7 +148,20 @@ pub fn local_testnet_config() -> ChainSpec {
 				.unwrap()
 				.into(),
 		],
-		vec![],
+		vec![
+			get_account_id_from_seed::<sr25519::Public>("Alice"),
+			get_account_id_from_seed::<sr25519::Public>("Bob"),
+			get_account_id_from_seed::<sr25519::Public>("Charlie"),
+			get_account_id_from_seed::<sr25519::Public>("Dave"),
+			get_account_id_from_seed::<sr25519::Public>("Eve"),
+			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+			get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+			get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+			get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+			get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+			get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+			get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+		],
 		sr25519::Public::from_str("5Cu7qY3UMoejWDnzR1ZVfEUgVTqzJnvM6AE5FTnqard4dRP2") // seed: "//Idn-local-testnet-root"
 			.unwrap()
 			.into(),


### PR DESCRIPTION
This PR adds initial balance to the dummy accounts of the local Ideal Network Chain.