### PR TITLE
use dev as default pop up network

### DIFF
--- a/chains/ideal-network/network.toml
+++ b/chains/ideal-network/network.toml
@@ -12,8 +12,8 @@ name = "bob"
 validator = true
 
 [[parachains]]
-id = 4502
-chain = "local"
+id = 2000
+chain = "dev"
 default_command = "../../target/release/idn-node"
 default_args = [ "-lxcm=trace", "--enable-offchain-indexing=true" ]
 

--- a/chains/ideal-network/node/src/chain_spec.rs
+++ b/chains/ideal-network/node/src/chain_spec.rs
@@ -91,7 +91,7 @@ pub fn dev_config() -> ChainSpec {
 		Extensions {
 			relay_chain: "paseo-local".into(),
 			// You MUST set this to the correct network!
-			para_id: 1000,
+			para_id: 2000,
 		},
 	)
 	.with_name("IDN Development")
@@ -118,7 +118,7 @@ pub fn dev_config() -> ChainSpec {
 			get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 		],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
-		1000.into(),
+		2000.into(),
 	))
 	.build()
 }


### PR DESCRIPTION
Small update to make sure that the default network on the pop toml file is the `dev` one, so that spinning it up will prefund some accounts for ease of development and manual testing.

After this PR is merged (and after rebuild), running `pop up network -f ./network.toml` as specified in the readme will spin up an idn parachain and paseo relay, both with prefunded accounts 