### PR TITLE
fix/runtime config for rand beacon ingestion

### DIFF
--- a/chains/ideal-network/node/src/service.rs
+++ b/chains/ideal-network/node/src/service.rs
@@ -427,7 +427,8 @@ pub async fn start_parachain_node(
 	if validator {
 		// tracks incoming protobuf messages from the gossipsub topic
 		let (tx, rx) = tracing_unbounded("drand-notification-channel", 100);
-		// reads raw (protobuf) pulses from rx and puts them into FIFO queue (with limit MAX_QUEUE_SIZE)
+		// reads raw (protobuf) pulses from rx and puts them into FIFO queue (with limit
+		// MAX_QUEUE_SIZE)
 		let pulse_receiver = DrandReceiver::<MAX_QUEUE_SIZE>::new(rx);
 
 		let primary: Multiaddr =

--- a/chains/ideal-network/node/src/service.rs
+++ b/chains/ideal-network/node/src/service.rs
@@ -425,7 +425,9 @@ pub async fn start_parachain_node(
 	})?;
 
 	if validator {
-		let (tx, rx) = tracing_unbounded("drand-notification-channel", 10000);
+		// tracks incoming protobuf messages from the gossipsub topic
+		let (tx, rx) = tracing_unbounded("drand-notification-channel", 100);
+		// reads raw (protobuf) pulses from rx and puts them into FIFO queue (with limit MAX_QUEUE_SIZE)
 		let pulse_receiver = DrandReceiver::<MAX_QUEUE_SIZE>::new(rx);
 
 		let primary: Multiaddr =

--- a/chains/ideal-network/runtime/src/configs/mod.rs
+++ b/chains/ideal-network/runtime/src/configs/mod.rs
@@ -306,11 +306,15 @@ impl pallet_idn_manager::Config for Runtime {
 	type SiblingOrigin = bench_ensure_origin::BenchEnsureOrigin;
 }
 
+parameter_types! {
+	pub const MaxSigsPerBlock: u8 = crate::constants::idn::MAX_QUEUE_SIZE as u8;
+}
+
 impl pallet_randomness_beacon::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type WeightInfo = RandomnessBeaconWeightInfo<Runtime>;
 	type SignatureVerifier = sp_idn_crypto::verifier::QuicknetVerifier;
-	type MaxSigsPerBlock = ConstU8<5>;
+	type MaxSigsPerBlock = MaxSigsPerBlock;
 	type Pulse = types::RuntimePulse;
 	type Dispatcher = crate::IdnManager;
 }

--- a/chains/ideal-network/runtime/src/constants/idn.rs
+++ b/chains/ideal-network/runtime/src/constants/idn.rs
@@ -26,6 +26,6 @@ pub const PRIMARY: &str =
 pub const SECONDARY: &str =
 	"/ip4/54.193.191.250/tcp/44544/p2p/12D3KooWQqDi3D3KLfDjWATQUUE4o5aSshwBFi9JM36wqEPMPD5y";
 /// The maximum queue size for the mpsc channel that stores raw pulse data (protobuf)
-pub const MAX_QUEUE_SIZE: usize = 100;
+pub const MAX_QUEUE_SIZE: usize = 6;
 /// The number of seconds the node waits without a new message until it restarts the swarm
 pub const NO_MESSAGE_TIMEOUT: usize = 12;


### PR DESCRIPTION
The runtime config for the idn-node was misconfigured, introducing a mismatch between the number of pulses that collators try to aggregate and inject (via create_inherent). This results in an `ExcessiveHeight` error blocking signatures from being accepted. 

To elaborate, there is an MPSC channel that stores raw protobuf messages received from the gossipsub topic. This can be any value as long as it's greater than the maxmium number of pulses per block. There is also a VecDequeue that operates as a FIFO queue for `formatted` pulses (CanonicalPulse). The issue arose in the maximum size of this VecDequeue being greater than the maximum number of rounds we can publish in a single block. This resolves it by ensuring they use the same size.