### PR TITLE
Feat/calc credits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9393,6 +9393,7 @@ dependencies = [
  "pallet-balances",
  "pallet-xcm",
  "parity-scale-codec",
+ "proptest",
  "scale-info",
  "sha2 0.10.9",
  "simple-mermaid",
@@ -12812,17 +12813,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -13117,11 +13118,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,9 @@ tokio = { version = "^1", features = ["full"] }
 tracing = { version = "0.1.41" }
 tracing-test = { version = " 0.2.5" }
 
+# Testing
+proptest = "1.7.0"
+
 # Serialization
 array-bytes = { version = "6.2.2", default-features = false }
 hex = { version = "0.4", features = ["serde"], default-features = false }

--- a/pallets/idn-manager/Cargo.toml
+++ b/pallets/idn-manager/Cargo.toml
@@ -42,6 +42,7 @@ sp-consensus-randomness-beacon.workspace = true
 pallet-balances.workspace = true
 sp-version.workspace = true
 xcm-executor.workspace = true
+proptest.workspace = true
 
 [features]
 default = ["std"]

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -107,6 +107,8 @@ impl<Treasury, Sub, Balances>
 	FeesManager<
 		Balances::Balance,
 		u64,
+		u64,
+		u64,
 		Sub,
 		DispatchError,
 		AccountId32,

--- a/pallets/idn-manager/src/impls.rs
+++ b/pallets/idn-manager/src/impls.rs
@@ -254,12 +254,12 @@ where
 	}
 
 	/// Get the number of credits consumed by a subscription when this one gets a pulse in a block.
-	fn get_consume_credits(_sub: &Sub) -> u64 {
+	fn get_consume_credits(_sub: Option<&Sub>) -> u64 {
 		1000
 	}
 
 	/// Get the number of credits consumed by a subscription when this one is idle in a block.
-	fn get_idle_credits(_sub: &Sub) -> u64 {
+	fn get_idle_credits(_sub: Option<&Sub>) -> u64 {
 		10
 	}
 }

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -834,7 +834,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub(crate) fn get_min_credits(sub: &SubscriptionOf<T>) -> T::Credits {
-		T::FeesManager::get_idle_credits(sub)
+		T::FeesManager::get_idle_credits(Some(sub))
 	}
 
 	/// Distribute randomness to subscribers
@@ -853,7 +853,7 @@ impl<T: Config> Pallet<T> {
 					current_block >= sub.last_delivered.unwrap() + sub.frequency)
 			{
 				// Make sure credits are consumed before sending the XCM message
-				let consume_credits = T::FeesManager::get_consume_credits(&sub);
+				let consume_credits = T::FeesManager::get_consume_credits(Some(&sub));
 
 				if let Err(e) = Self::collect_fees(&sub, consume_credits) {
 					Self::pause_subscription_on_error(sub_id, sub, "Failed to collect fees", e);
@@ -881,7 +881,7 @@ impl<T: Config> Pallet<T> {
 
 				Self::deposit_event(Event::RandomnessDistributed { sub_id });
 			} else {
-				let idle_credits = T::FeesManager::get_idle_credits(&sub);
+				let idle_credits = T::FeesManager::get_idle_credits(Some(&sub));
 				// Collect fees for idle block
 				if let Err(e) = Self::collect_fees(&sub, idle_credits) {
 					log::warn!(

--- a/pallets/idn-manager/src/lib.rs
+++ b/pallets/idn-manager/src/lib.rs
@@ -267,6 +267,8 @@ pub mod pallet {
 		type FeesManager: FeesManager<
 			BalanceOf<Self>,
 			Self::Credits,
+			Self::Credits,
+			Self::Credits,
 			SubscriptionOf<Self>,
 			DispatchError,
 			<Self as frame_system::pallet::Config>::AccountId,

--- a/pallets/idn-manager/src/tests/mod.rs
+++ b/pallets/idn-manager/src/tests/mod.rs
@@ -21,4 +21,5 @@
 pub(crate) mod mock;
 mod pallet;
 mod primitives;
+mod traits;
 mod xcm_controller;

--- a/pallets/idn-manager/src/tests/pallet.rs
+++ b/pallets/idn-manager/src/tests/pallet.rs
@@ -720,7 +720,7 @@ fn test_credits_consumption_and_cleanup() {
 			// Verify credit consumption
 			let sub = Subscriptions::<Test>::get(sub_id).unwrap();
 
-			let consume_credits = <Test as Config>::FeesManager::get_consume_credits(&sub);
+			let consume_credits = <Test as Config>::FeesManager::get_consume_credits(Some(&sub));
 
 			assert_eq!(
 				sub.credits_left,
@@ -958,14 +958,14 @@ fn test_credits_consumption_frequency() {
 				));
 				assert_eq!(
 					sub.credits_left,
-					credits_left - <Test as Config>::FeesManager::get_consume_credits(&sub)
+					credits_left - <Test as Config>::FeesManager::get_consume_credits(Some(&sub))
 				);
 			} else {
 				// Verify events
 				assert!(event_not_emitted(Event::<Test>::RandomnessDistributed { sub_id }));
 				assert_eq!(
 					sub.credits_left,
-					credits_left - <Test as Config>::FeesManager::get_idle_credits(&sub)
+					credits_left - <Test as Config>::FeesManager::get_idle_credits(Some(&sub))
 				);
 			}
 

--- a/pallets/idn-manager/src/tests/traits.rs
+++ b/pallets/idn-manager/src/tests/traits.rs
@@ -88,7 +88,7 @@ proptest! {
 		if n < u32::MAX/(idle*f - consume) && f < u32::MAX/idle {
 			let expected = n * (f * idle + consume);
 			let result = DummyFeesManager::calculate_credits(f, n);
- 
+
 			prop_assert_eq!(result, expected);
 		}
 	}

--- a/pallets/idn-manager/src/tests/traits.rs
+++ b/pallets/idn-manager/src/tests/traits.rs
@@ -66,29 +66,29 @@ impl FeesManager<u32, u32, u32, u32, (), (), (), DiffBalanceImpl<u32>> for Dummy
 		Ok(*fees)
 	}
 
-	fn get_consume_credits(_sub: &()) -> u32 {
+	fn get_consume_credits(_sub: Option<&()>) -> u32 {
 		// Consuming a pulse costs 1000 credits
-		10
+		1000
 	}
 
-	fn get_idle_credits(_sub: &()) -> u32 {
+	fn get_idle_credits(_sub: Option<&()>) -> u32 {
 		// Skipping a pulse costs 10 credits
-		1
+		10
 	}
 }
 
 proptest! {
 	#[test]
 	fn test_calculate_credits_proptest(f in 1u32..u32::MAX, n in 1u32..u32::MAX) {
-		let consume = DummyFeesManager::get_consume_credits(&());
-		let idle = DummyFeesManager::get_idle_credits(&());
+		let consume = DummyFeesManager::get_consume_credits(None);
+		let idle = DummyFeesManager::get_idle_credits(None);
 		// this line will overflow if it exceeds u32::MAX: n * (10f + 1000) > 4,294,967,295
 		// so we need to make sure: n <= u32::MAX/(10f - 1000)
 		// we must also have idle*f < u32::MAX, so we need f < u32::MAX/idle to avoid an overflowF
 		if n < u32::MAX/(idle*f - consume) && f < u32::MAX/idle {
 			let expected = n * (f * idle + consume);
-			let result = DummyFeesManager::calculate_credits(&(), f, n);
-
+			let result = DummyFeesManager::calculate_credits(f, n);
+ 
 			prop_assert_eq!(result, expected);
 		}
 	}

--- a/pallets/idn-manager/src/tests/traits.rs
+++ b/pallets/idn-manager/src/tests/traits.rs
@@ -68,7 +68,7 @@ impl FeesManager<u32, u32, u32, u32, (), (), (), DiffBalanceImpl<u32>> for Dummy
 
 	fn get_consume_credits(_sub: Option<&()>) -> u32 {
 		// Consuming a pulse costs 1000 credits
-		1000
+		100
 	}
 
 	fn get_idle_credits(_sub: Option<&()>) -> u32 {
@@ -85,7 +85,7 @@ proptest! {
 		// this line will overflow if it exceeds u32::MAX: n * (10f + 1000) > 4,294,967,295
 		// so we need to make sure: n <= u32::MAX/(10f - 1000)
 		// we must also have idle*f < u32::MAX, so we need f < u32::MAX/idle to avoid an overflowF
-		if n < u32::MAX/(idle*f - consume) && f < u32::MAX/idle {
+		if f < u32::MAX/(2 * idle) && n < u32::MAX/(idle*f - consume) {
 			let expected = n * (f * idle + consume);
 			let result = DummyFeesManager::calculate_credits(f, n);
 

--- a/pallets/idn-manager/src/tests/traits.rs
+++ b/pallets/idn-manager/src/tests/traits.rs
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 by Ideal Labs, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! # Tests for the IDN Manager traits
+use crate::traits::{BalanceDirection, DiffBalance, FeesError, FeesManager};
+use proptest::prelude::*;
+use sp_runtime::traits::Zero;
+use sp_std::cmp::Ordering;
+
+struct DummyFeesManager;
+/// A simple implementation of the `DiffBalance` trait.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct DiffBalanceImpl<Balance> {
+	balance: Balance,
+	direction: BalanceDirection,
+}
+
+impl<Balance: Copy> DiffBalance<Balance> for DiffBalanceImpl<Balance> {
+	fn balance(&self) -> Balance {
+		self.balance
+	}
+	fn direction(&self) -> BalanceDirection {
+		self.direction
+	}
+	fn new(balance: Balance, direction: BalanceDirection) -> Self {
+		Self { balance, direction }
+	}
+}
+
+impl FeesManager<u32, u32, u32, u32, (), (), (), DiffBalanceImpl<u32>> for DummyFeesManager {
+	fn calculate_subscription_fees(_credits: &u32) -> u32 {
+		0
+	}
+
+	fn calculate_diff_fees(old_credits: &u32, new_credits: &u32) -> DiffBalanceImpl<u32> {
+		let mut direction = BalanceDirection::None;
+		let fees = match new_credits.cmp(old_credits) {
+			Ordering::Greater => {
+				direction = BalanceDirection::Collect;
+				Self::calculate_subscription_fees(&new_credits.saturating_sub(*old_credits))
+			},
+			Ordering::Less => {
+				direction = BalanceDirection::Release;
+				Self::calculate_subscription_fees(&old_credits.saturating_sub(*new_credits))
+			},
+			Ordering::Equal => Zero::zero(),
+		};
+		DiffBalanceImpl::new(fees, direction)
+	}
+
+	fn collect_fees(fees: &u32, _: &()) -> Result<u32, FeesError<u32, ()>> {
+		// In this case we are not collecting any fees
+		Ok(*fees)
+	}
+
+	fn get_consume_credits(_sub: &()) -> u32 {
+		// Consuming a pulse costs 1000 credits
+		10
+	}
+
+	fn get_idle_credits(_sub: &()) -> u32 {
+		// Skipping a pulse costs 10 credits
+		1
+	}
+}
+
+proptest! {
+	#[test]
+	fn test_calculate_credits_proptest(f in 1u32..u32::MAX, n in 1u32..u32::MAX) {
+		let consume = DummyFeesManager::get_consume_credits(&());
+		let idle = DummyFeesManager::get_idle_credits(&());
+		// this line will overflow if it exceeds u32::MAX: n * (10f + 1000) > 4,294,967,295
+		// so we need to make sure: n <= u32::MAX/(10f - 1000)
+		// we must also have idle*f < u32::MAX, so we need f < u32::MAX/idle to avoid an overflowF
+		if n < u32::MAX/(idle*f - consume) && f < u32::MAX/idle {
+			let expected = n * (f * idle + consume);
+			let result = DummyFeesManager::calculate_credits(&(), f, n);
+
+			prop_assert_eq!(result, expected);
+		}
+	}
+}

--- a/pallets/idn-manager/src/traits/example.rs
+++ b/pallets/idn-manager/src/traits/example.rs
@@ -76,12 +76,12 @@ mod linear_fee_calculator {
 			Ok(*fees)
 		}
 
-		fn get_consume_credits(_sub: &()) -> u32 {
+		fn get_consume_credits(_sub: Option<&()>) -> u32 {
 			// Consuming a pulse costs 1000 credits
 			1000
 		}
 
-		fn get_idle_credits(_sub: &()) -> u32 {
+		fn get_idle_credits(_sub: Option<&()>) -> u32 {
 			// Skipping a pulse costs 10 credits
 			10
 		}
@@ -152,11 +152,11 @@ mod tiered_fee_calculator {
 			// In this case we are not collecting any fees
 			Ok(*fees)
 		}
-		fn get_consume_credits(_sub: &()) -> u32 {
+		fn get_consume_credits(_sub: Option<&()>) -> u32 {
 			// Consuming a pulse costs 1000 credits
 			1000
 		}
-		fn get_idle_credits(_sub: &()) -> u32 {
+		fn get_idle_credits(_sub: Option<&()>) -> u32 {
 			// Skipping a pulse costs 10 credits
 			10
 		}

--- a/pallets/idn-manager/src/traits/example.rs
+++ b/pallets/idn-manager/src/traits/example.rs
@@ -50,7 +50,6 @@ const BASE_FEE: u32 = 100;
 mod linear_fee_calculator {
 	use super::*;
 	impl FeesManager<u32, u32, u32, u32, (), (), (), DiffBalanceImpl<u32>> for LinearFeeCalculator {
-
 		fn calculate_subscription_fees(credits: &u32) -> u32 {
 			BASE_FEE.saturating_mul(*credits)
 		}
@@ -94,7 +93,9 @@ pub struct SteppedTieredFeeCalculator;
 #[docify::export_content]
 mod tiered_fee_calculator {
 	use super::*;
-	impl FeesManager<u32, u32, u32, u32, (), (), (), DiffBalanceImpl<u32>> for SteppedTieredFeeCalculator {
+	impl FeesManager<u32, u32, u32, u32, (), (), (), DiffBalanceImpl<u32>>
+		for SteppedTieredFeeCalculator
+	{
 		fn calculate_subscription_fees(credits: &u32) -> u32 {
 			// Define tier boundaries and their respective discount rates (in basis points)
 			const TIERS: [(u32, u32); 5] = [

--- a/pallets/idn-manager/src/traits/example.rs
+++ b/pallets/idn-manager/src/traits/example.rs
@@ -49,10 +49,12 @@ const BASE_FEE: u32 = 100;
 #[docify::export_content]
 mod linear_fee_calculator {
 	use super::*;
-	impl FeesManager<u32, u32, (), (), (), DiffBalanceImpl<u32>> for LinearFeeCalculator {
+	impl FeesManager<u32, u32, u32, u32, (), (), (), DiffBalanceImpl<u32>> for LinearFeeCalculator {
+
 		fn calculate_subscription_fees(credits: &u32) -> u32 {
 			BASE_FEE.saturating_mul(*credits)
 		}
+
 		fn calculate_diff_fees(old_credits: &u32, new_credits: &u32) -> DiffBalanceImpl<u32> {
 			let mut direction = BalanceDirection::None;
 			let fees = match new_credits.cmp(old_credits) {
@@ -68,14 +70,17 @@ mod linear_fee_calculator {
 			};
 			DiffBalanceImpl::new(fees, direction)
 		}
+
 		fn collect_fees(fees: &u32, _: &()) -> Result<u32, FeesError<u32, ()>> {
 			// In this case we are not collecting any fees
 			Ok(*fees)
 		}
+
 		fn get_consume_credits(_sub: &()) -> u32 {
 			// Consuming a pulse costs 1000 credits
 			1000
 		}
+
 		fn get_idle_credits(_sub: &()) -> u32 {
 			// Skipping a pulse costs 10 credits
 			10
@@ -89,7 +94,7 @@ pub struct SteppedTieredFeeCalculator;
 #[docify::export_content]
 mod tiered_fee_calculator {
 	use super::*;
-	impl FeesManager<u32, u32, (), (), (), DiffBalanceImpl<u32>> for SteppedTieredFeeCalculator {
+	impl FeesManager<u32, u32, u32, u32, (), (), (), DiffBalanceImpl<u32>> for SteppedTieredFeeCalculator {
 		fn calculate_subscription_fees(credits: &u32) -> u32 {
 			// Define tier boundaries and their respective discount rates (in basis points)
 			const TIERS: [(u32, u32); 5] = [

--- a/pallets/idn-manager/src/traits/mod.rs
+++ b/pallets/idn-manager/src/traits/mod.rs
@@ -34,6 +34,7 @@
 //! distribution.
 //!
 //! **Methods:**
+//!   - [`calculate_credits`](FeesManager::calculate_credits): Calculates the minimum number of credits required to power a subscription given its frequency and desired number of pulses
 //!   - [`calculate_subscription_fees`](FeesManager::calculate_subscription_fees): Determines the
 //!     initial fee for a subscription based on the requested credits.
 //!   - [`calculate_diff_fees`](FeesManager::calculate_diff_fees): Calculates the difference in fees
@@ -137,7 +138,37 @@ pub trait DiffBalance<Balance> {
 #[doc = docify::embed!("./src/traits/example.rs", linear_fee_calculator)]
 /// - Tiered fee calculator: where the fees are calculated based on a tiered function.
 #[doc = docify::embed!("./src/traits/example.rs", tiered_fee_calculator)]
-pub trait FeesManager<Fees, Credits, Sub: Subscription<S>, Err, S, Diff: DiffBalance<Fees>> {
+pub trait FeesManager<
+	Fees,
+	Credits,
+	F,
+	P,
+	Sub: Subscription<S>,
+	Err,
+	S,
+	Diff: DiffBalance<Fees>,
+> where
+	Credits: sp_runtime::Saturating,
+	P: Into<Credits> + sp_runtime::Saturating,
+	F: Into<Credits> + sp_runtime::Saturating,
+{
+	/// Calculate the minimum number of credits required to power the subscription under the given frequency and lifetime
+	/// credit calculation pertains to subscription frequency and lifetime, agnostic of fees or impl.
+	/// Note: if the subscription is paused during its lifetime, additional credits may be required.
+	///
+	/// Credits are calculated as: `lifetime * [(frequency - 1) * idle_credit + execute_credits]`
+	/// where
+	///
+	/// * `frequency`: The (static) number of blocks to wait between pulse delivery
+	/// * `lifetime`: The desired number of pulses to be delivered during the subscription's lifetime
+	///
+	fn calculate_credits(sub: &Sub, frequency: F, lifetime: P) -> Credits {
+		lifetime.into().saturating_mul(
+			frequency.into().saturating_mul(Self::get_idle_credits(sub))
+			.saturating_add(Self::get_consume_credits(sub))
+		).into()
+	}
+
 	/// Calculate the fees for a subscription based on the credits of pulses required.
 	fn calculate_subscription_fees(credits: &Credits) -> Fees;
 	/// Calculate how much fees should be held or release when a subscription changes.

--- a/pallets/idn-manager/src/traits/mod.rs
+++ b/pallets/idn-manager/src/traits/mod.rs
@@ -34,7 +34,8 @@
 //! distribution.
 //!
 //! **Methods:**
-//!   - [`calculate_credits`](FeesManager::calculate_credits): Calculates the minimum number of credits required to power a subscription given its frequency and desired number of pulses
+//!   - [`calculate_credits`](FeesManager::calculate_credits): Calculates the minimum number of
+//!     credits required to power a subscription given its frequency and desired number of pulses
 //!   - [`calculate_subscription_fees`](FeesManager::calculate_subscription_fees): Determines the
 //!     initial fee for a subscription based on the requested credits.
 //!   - [`calculate_diff_fees`](FeesManager::calculate_diff_fees): Calculates the difference in fees
@@ -138,35 +139,33 @@ pub trait DiffBalance<Balance> {
 #[doc = docify::embed!("./src/traits/example.rs", linear_fee_calculator)]
 /// - Tiered fee calculator: where the fees are calculated based on a tiered function.
 #[doc = docify::embed!("./src/traits/example.rs", tiered_fee_calculator)]
-pub trait FeesManager<
-	Fees,
-	Credits,
-	F,
-	P,
-	Sub: Subscription<S>,
-	Err,
-	S,
-	Diff: DiffBalance<Fees>,
-> where
+pub trait FeesManager<Fees, Credits, F, P, Sub: Subscription<S>, Err, S, Diff: DiffBalance<Fees>>
+where
 	Credits: sp_runtime::Saturating,
 	P: Into<Credits> + sp_runtime::Saturating,
 	F: Into<Credits> + sp_runtime::Saturating,
 {
-	/// Calculate the minimum number of credits required to power the subscription under the given frequency and lifetime
-	/// credit calculation pertains to subscription frequency and lifetime, agnostic of fees or impl.
-	/// Note: if the subscription is paused during its lifetime, additional credits may be required.
+	/// Calculate the minimum number of credits required to power the subscription under the given
+	/// frequency and lifetime credit calculation pertains to subscription frequency and lifetime,
+	/// agnostic of fees or impl. Note: if the subscription is paused during its lifetime,
+	/// additional credits may be required.
 	///
 	/// Credits are calculated as: `lifetime * [(frequency - 1) * idle_credit + execute_credits]`
 	/// where
 	///
 	/// * `frequency`: The (static) number of blocks to wait between pulse delivery
-	/// * `lifetime`: The desired number of pulses to be delivered during the subscription's lifetime
-	///
+	/// * `lifetime`: The desired number of pulses to be delivered during the subscription's
+	///   lifetime
 	fn calculate_credits(frequency: F, lifetime: P) -> Credits {
-		lifetime.into().saturating_mul(
-			frequency.into().saturating_mul(Self::get_idle_credits(None))
-			.saturating_add(Self::get_consume_credits(None))
-		).into()
+		lifetime
+			.into()
+			.saturating_mul(
+				frequency
+					.into()
+					.saturating_mul(Self::get_idle_credits(None))
+					.saturating_add(Self::get_consume_credits(None)),
+			)
+			.into()
 	}
 
 	/// Calculate the fees for a subscription based on the credits of pulses required.

--- a/pallets/idn-manager/src/traits/mod.rs
+++ b/pallets/idn-manager/src/traits/mod.rs
@@ -157,14 +157,12 @@ where
 	/// * `lifetime`: The desired number of pulses to be delivered during the subscription's
 	///   lifetime
 	fn calculate_credits(frequency: F, lifetime: P) -> Credits {
-		lifetime
-			.into()
-			.saturating_mul(
-				frequency
-					.into()
-					.saturating_mul(Self::get_idle_credits(None))
-					.saturating_add(Self::get_consume_credits(None)),
-			)
+		lifetime.into().saturating_mul(
+			frequency
+				.into()
+				.saturating_mul(Self::get_idle_credits(None))
+				.saturating_add(Self::get_consume_credits(None)),
+		)
 	}
 
 	/// Calculate the fees for a subscription based on the credits of pulses required.

--- a/pallets/idn-manager/src/traits/mod.rs
+++ b/pallets/idn-manager/src/traits/mod.rs
@@ -162,10 +162,10 @@ pub trait FeesManager<
 	/// * `frequency`: The (static) number of blocks to wait between pulse delivery
 	/// * `lifetime`: The desired number of pulses to be delivered during the subscription's lifetime
 	///
-	fn calculate_credits(sub: &Sub, frequency: F, lifetime: P) -> Credits {
+	fn calculate_credits(frequency: F, lifetime: P) -> Credits {
 		lifetime.into().saturating_mul(
-			frequency.into().saturating_mul(Self::get_idle_credits(sub))
-			.saturating_add(Self::get_consume_credits(sub))
+			frequency.into().saturating_mul(Self::get_idle_credits(None))
+			.saturating_add(Self::get_consume_credits(None))
 		).into()
 	}
 
@@ -181,9 +181,9 @@ pub trait FeesManager<
 	/// Distributes collected fees. Returns the fees that were effectively collected.
 	fn collect_fees(fees: &Fees, sub: &Sub) -> Result<Fees, FeesError<Fees, Err>>;
 	/// Returns how many credits this subscription pays for receiving a pulse
-	fn get_consume_credits(sub: &Sub) -> Credits;
+	fn get_consume_credits(sub: Option<&Sub>) -> Credits;
 	/// Returns how many credits this subscription pays for skipping to receive a pulse
-	fn get_idle_credits(sub: &Sub) -> Credits;
+	fn get_idle_credits(sub: Option<&Sub>) -> Credits;
 }
 
 /// Trait for accessing subscription information.

--- a/pallets/idn-manager/src/traits/mod.rs
+++ b/pallets/idn-manager/src/traits/mod.rs
@@ -165,7 +165,6 @@ where
 					.saturating_mul(Self::get_idle_credits(None))
 					.saturating_add(Self::get_consume_credits(None)),
 			)
-			.into()
 	}
 
 	/// Calculate the fees for a subscription based on the credits of pulses required.


### PR DESCRIPTION
Closes #237 

This PR introduces a new **provided** function to the FeesManager trait, `calculate_credits` that outputs a minimum number of credits requires to power a subscription given a frequency (between pulses) and a number of dispatch events. Specifically, it computes:

`(frequency, number_of_pulses) -> number_of_pulses * (frequency * C + C')`

where `C := idle credit rate` and `C' := execute credit rate`.